### PR TITLE
feat: nested entry points

### DIFF
--- a/.changeset/giant-bottles-give.md
+++ b/.changeset/giant-bottles-give.md
@@ -1,0 +1,8 @@
+---
+'@flatfile/listener': major
+'@flatfile/javascript': minor
+'@flatfile/v2-shims': minor
+'@flatfile/react': minor
+---
+
+Update package.json to use exports nested entrypoints

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -2,15 +2,23 @@
   "name": "@flatfile/javascript",
   "version": "1.1.8",
   "description": "Flatfile embedded with vanilla javascript.",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "browser": {
+      "require": "./dist/index.browser.cjs",
+      "import": "./dist/index.browser.mjs"
+    },
+    "default": "./dist/index.mjs"
+  },
   "source": "src/index.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "browser": {
-    "./dist/index.cjs": "./dist/index.browser.cjs",
-    "./dist/index.mjs": "./dist/index.browser.mjs"
-  },
   "types": "./dist/index.d.ts",
-  "type": "module",
   "engines": {
     "node": ">= 12"
   },

--- a/packages/listener/package.json
+++ b/packages/listener/package.json
@@ -2,14 +2,23 @@
   "name": "@flatfile/listener",
   "version": "0.4.2",
   "description": "A PubSub Listener for configuring and using Flatfile",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "browser": {
+      "require": "./dist/index.browser.cjs",
+      "import": "./dist/index.browser.mjs"
+    },
+    "default": "./dist/index.mjs"
+  },
+  "source": "src/index.ts",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "type": "module",
-  "browser": {
-    "./dist/index.cjs": "./dist/index.browser.cjs",
-    "./dist/index.mjs": "./dist/index.browser.mjs"
-  },
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "build": "rollup -c",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,14 +2,23 @@
   "name": "@flatfile/react",
   "version": "7.7.4",
   "description": "Flatfile React components",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "browser": {
+      "require": "./dist/index.browser.cjs",
+      "import": "./dist/index.browser.mjs"
+    },
+    "default": "./dist/index.mjs"
+  },
+  "source": "index.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "browser": {
-    "./dist/index.cjs": "./dist/index.browser.cjs",
-    "./dist/index.mjs": "./dist/index.browser.mjs"
-  },
   "types": "./dist/index.d.ts",
-  "type": "module",
   "author": "",
   "license": "ISC",
   "files": [

--- a/packages/v2-shims/package.json
+++ b/packages/v2-shims/package.json
@@ -2,13 +2,22 @@
   "name": "@flatfile/v2-shims",
   "version": "1.0.1",
   "description": "A collection of helpers for migrating from v2 to platform",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "browser": {
+      "require": "./dist/index.browser.cjs",
+      "import": "./dist/index.browser.mjs"
+    },
+    "default": "./dist/index.mjs"
+  },
+  "source": "src/index.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "type": "module",
-  "browser": {
-    "./dist/index.cjs": "./dist/index.browser.cjs",
-    "./dist/index.mjs": "./dist/index.browser.mjs"
-  },
   "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",


### PR DESCRIPTION
Switches from using the browser overrides to using nested entry points that include browser entries. 
- [x] `@flatfile/javascript`
- [x] `@flatfile/react`
- [x] `@flatfile/v2-shims`
- [x] `@flatfile/listener`