### PR TITLE
feat: update deps of useCreateListener to remount the listener when updating the accesstoken

### DIFF
--- a/.changeset/tough-ants-fry.md
+++ b/.changeset/tough-ants-fry.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fixes a bug with updating the listener authentication

--- a/packages/react/src/hooks/useCreateListener.ts
+++ b/packages/react/src/hooks/useCreateListener.ts
@@ -28,7 +28,7 @@ export const useCreateListener = ({
           fetchApi: fetch,
         })
       )
-  }, [listener])
+  }, [listener, accessToken, apiUrl])
 
   return {
     dispatchEvent: (event: any) => {


### PR DESCRIPTION
Fixes an issue, where updating the accessToken from creating a space doesn't actually refresh the Listener.