### PR TITLE
Fix develop confirm prompt firing when there are no agents

### DIFF
--- a/.changeset/silver-rivers-collect.md
+++ b/.changeset/silver-rivers-collect.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Develop does not need confirmation if there are no deployed agents

--- a/packages/cli/src/shared/localized/en-us.ts
+++ b/packages/cli/src/shared/localized/en-us.ts
@@ -93,7 +93,7 @@ ${chalk.dim(text)}`,
     
   ${chalk.dim(text)}`,
 
-  error: (text: any) => `\nAn error occurred
+  error: (text: any) => `An error occurred
   
   Please check logs for details:
   ${chalk.dim(text)}`,

--- a/packages/cli/src/x/actions/develop.action.ts
+++ b/packages/cli/src/x/actions/develop.action.ts
@@ -59,19 +59,20 @@ export async function developAction(
     })
     if (agents?.data && agents?.data?.length > 0) {
       console.error(messages.warnDeployedAgents(agents.data))
-    }
+  
+      const { developLocally } = await prompts({
+        type: 'confirm',
+        name: 'developLocally',
+        message: 'Would you like to proceed listening locally? (y/n)',
+      })
 
-    const { developLocally } = await prompts({
-      type: 'confirm',
-      name: 'developLocally',
-      message: 'Would you like to proceed listening locally? (y/n)',
-    })
+      if (!developLocally) {
+        ora({
+          text: `Local development aborted`,
+        }).fail()
+        process.exit(1)
+      }
 
-    if (!developLocally) {
-      ora({
-        text: `Local development aborted`,
-      }).fail()
-      process.exit(1)
     }
 
     const driver = new PubSubDriver(environment.id)


### PR DESCRIPTION
## Please tell Chat GPT how to summarize this PR:

A prompt does not appear to confirm development unless there are deployed agents

## Tell code reviewer how and what to test:

Develop on an env without an agent