### PR TITLE
Ensure cron events can be passed as event topics

### DIFF
--- a/.changeset/twelve-oranges-speak.md
+++ b/.changeset/twelve-oranges-speak.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Validates cron and legacy events if passed as topics

--- a/packages/cli/src/shared/constants.ts
+++ b/packages/cli/src/shared/constants.ts
@@ -69,6 +69,15 @@ export const deployTopics = [
 
 export const allTopics = [
   ...deployTopics, 
+  // Add legacy topics
+  'workbook:added',
+  'sheet:validated',
+  'upload:completed',
+  'job:waiting',
+  'job:started',
+  'client:init',
+  'action:triggered',
+  // Add cron topics
   'cron:5-minutes',
   'cron:hourly',
   'cron:daily',

--- a/packages/cli/src/shared/constants.ts
+++ b/packages/cli/src/shared/constants.ts
@@ -67,6 +67,14 @@ export const deployTopics = [
   'secret:deleted',
 ] as Flatfile.EventTopic[]
 
+export const allTopics = [
+  ...deployTopics, 
+  'cron:5-minutes',
+  'cron:hourly',
+  'cron:daily',
+  'cron:weekly',
+] as Flatfile.EventTopic[]
+
 export const AUTODETECT_FILE_PATHS = [
   path.join(process.cwd(), 'index.js'),
   path.join(process.cwd(), 'index.ts'),

--- a/packages/cli/src/x/actions/deploy.action.ts
+++ b/packages/cli/src/x/actions/deploy.action.ts
@@ -13,7 +13,7 @@ import util from 'util'
 
 import { agentTable } from '../helpers/agent.table'
 import { apiKeyClient } from './auth.action'
-import { deployTopics, tableConfig } from '../../shared/constants'
+import { deployTopics, allTopics, tableConfig } from '../../shared/constants'
 import { getAuth } from '../../shared/get-auth'
 import { getEntryFile } from '../../shared/get-entry-file'
 import { messages } from '../../shared/messages'
@@ -177,7 +177,7 @@ export async function deployAction(
 
 
       topics.split(',').forEach((t) => {
-        if (!deployTopics.some((topic) => topic === t)) {
+        if (!allTopics.some((topic) => topic === t)) {
           topicsSpinner.fail(
             `${chalk.yellow(
               `The topic "${t}" is not a valid topic.`


### PR DESCRIPTION
## Please tell Chat GPT how to summarize this PR:

Includes cron + legacy events in allowable topics

## Tell code reviewer how and what to test:

Attempt to pass a cron topic in via the -t/--topics flag or FLATFILE_AGENT_TOPICS

