### PR TITLE
fix: Only Include Params If Defined

### DIFF
--- a/.changeset/healthy-queens-march.md
+++ b/.changeset/healthy-queens-march.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/javascript': patch
+'@flatfile/react': patch
+---
+
+Fix to only include defined params in the space creation request

--- a/packages/javascript/FlatfileJavascript.ts
+++ b/packages/javascript/FlatfileJavascript.ts
@@ -345,9 +345,9 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
         autoConfigure: false,
         ...spaceBody,
         labels: ['embedded', ...(labels || [])],
-        namespace,
-        translationsPath,
-        languageOverride,
+        ...(namespace ? { namespace } : {}),
+        ...(translationsPath ? { translationsPath } : {}),
+        ...(languageOverride ? { languageOverride } : {}),
         metadata: {
           theme: themeConfig,
           sidebarConfig: sidebarConfig ? sidebarConfig : { showSidebar: false },

--- a/packages/react/src/utils/initializeSpace.tsx
+++ b/packages/react/src/utils/initializeSpace.tsx
@@ -38,13 +38,13 @@ export const initializeSpace = async (
     const limitedAccessApi = authenticate(publishableKey, apiUrl)
     const createSpaceRequest = {
       name,
-      namespace,
       autoConfigure: false,
       environmentId,
       ...spaceBody,
       labels: ['embedded', ...(labels || [])],
-      translationsPath,
-      languageOverride,
+      ...(namespace ? { namespace } : {}),
+      ...(translationsPath ? { translationsPath } : {}),
+      ...(languageOverride ? { languageOverride } : {}),
       metadata: {
         ...metadata,
         theme: themeConfig,


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
- fix: only include params if set (especially `namespace`, `translationPath`, and `languageOverride`)
- chore: changeset

## Tell code reviewer how and what to test:

