### PR TITLE
Feat: Make EnvironmentID Optional

### DIFF
--- a/.changeset/long-buses-allow.md
+++ b/.changeset/long-buses-allow.md
@@ -1,0 +1,8 @@
+---
+'@flatfile/embedded-utils': patch
+'@flatfile/javascript': patch
+'@flatfile/react': patch
+'@flatfile/vue': patch
+---
+
+Make environmentId optional

--- a/packages/embedded-utils/src/types/Space.ts
+++ b/packages/embedded-utils/src/types/Space.ts
@@ -131,7 +131,7 @@ interface BaseSpace {
    * Identifier for environment
    * Required
    */
-  environmentId: string
+  environmentId?: string
   /**
    * Listener for advanced functionality
    * Optional

--- a/packages/javascript/src/services/document.ts
+++ b/packages/javascript/src/services/document.ts
@@ -1,4 +1,4 @@
-import { UpdateSpaceInfo } from '../..'
+import { UpdateSpaceInfo } from '../types'
 
 export const createDocument = async (data: UpdateSpaceInfo) => {
   const { apiUrl, accessToken, document, spaceId } = data

--- a/packages/javascript/src/services/workbook.ts
+++ b/packages/javascript/src/services/workbook.ts
@@ -1,4 +1,4 @@
-import { UpdateSpaceInfo } from '../..'
+import { UpdateSpaceInfo } from '../types'
 import { Flatfile } from '@flatfile/api'
 
 export const createWorkbook = async (data: UpdateSpaceInfo) => {
@@ -13,7 +13,7 @@ export const createWorkbook = async (data: UpdateSpaceInfo) => {
     },
     body: JSON.stringify({
       spaceId,
-      environmentId,
+      ...(environmentId !== undefined && { environmentId }),
       ...workbook,
     }),
   })

--- a/packages/javascript/src/types/UpdateSpaceInfo.ts
+++ b/packages/javascript/src/types/UpdateSpaceInfo.ts
@@ -1,0 +1,24 @@
+import type { Flatfile } from '@flatfile/api'
+
+import {
+  ISidebarConfig,
+  IThemeConfig,
+  IUserInfo,
+} from '@flatfile/embedded-utils'
+
+export interface UpdateSpaceInfo {
+  apiUrl: string
+  publishableKey?: string
+  workbook?: Flatfile.CreateWorkbookConfig
+  spaceId: string
+  environmentId?: string
+  mountElement: string
+  errorTitle: string
+  themeConfig?: IThemeConfig
+  document?: Flatfile.DocumentConfig
+  sidebarConfig?: ISidebarConfig
+  userInfo?: Partial<IUserInfo>
+  spaceInfo?: Partial<IUserInfo>
+  accessToken: string
+  spaceBody?: any
+}

--- a/packages/javascript/src/types/index.ts
+++ b/packages/javascript/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './UpdateSpaceInfo'

--- a/packages/react/src/utils/_tests_/initializeSpace.spec.ts
+++ b/packages/react/src/utils/_tests_/initializeSpace.spec.ts
@@ -20,7 +20,6 @@ const mockWorkbook = {
 
 const mockSpaceProps: ISpace = {
   publishableKey: 'your-publishable-key',
-  environmentId: 'your-environment-id',
   name: 'your-space-name',
   workbook: mockWorkbook,
 }
@@ -42,19 +41,6 @@ describe('initializeSpace', () => {
 
     await expect(initializeSpace(invalidSpaceProps)).rejects.toThrowError(
       'Missing required publishable key'
-    )
-    expect(authenticateMock).not.toHaveBeenCalled()
-    expect(addSpaceInfoMock).not.toHaveBeenCalled()
-  })
-
-  it('should throw an error when environment id is missing', async () => {
-    const invalidSpaceProps: ISpace = {
-      ...mockSpaceProps,
-      environmentId: '',
-    }
-
-    await expect(initializeSpace(invalidSpaceProps)).rejects.toThrowError(
-      'Missing required environment id'
     )
     expect(authenticateMock).not.toHaveBeenCalled()
     expect(addSpaceInfoMock).not.toHaveBeenCalled()

--- a/packages/react/src/utils/addSpaceInfo.ts
+++ b/packages/react/src/utils/addSpaceInfo.ts
@@ -21,7 +21,7 @@ export const addSpaceInfo = async (
       const createdWorkbook = createWorkbookFromSheet(sheet)
       localWorkbook = await api.workbooks.create({
         spaceId,
-        environmentId,
+        ...(environmentId !== undefined && { environmentId }),
         ...createdWorkbook,
       })
 
@@ -32,7 +32,7 @@ export const addSpaceInfo = async (
     if (workbook) {
       localWorkbook = await api.workbooks.create({
         spaceId,
-        environmentId,
+        ...(environmentId !== undefined && { environmentId }),
         ...workbook,
       })
 

--- a/packages/react/src/utils/getSpace.tsx
+++ b/packages/react/src/utils/getSpace.tsx
@@ -9,7 +9,6 @@ export const getSpace = async (
   const {
     space,
     apiUrl,
-    environmentId,
     spaceUrl = 'https://platform.flatfile.com/s/',
   } = spaceProps
   let spaceResponse
@@ -19,10 +18,6 @@ export const getSpace = async (
     }
     if (!space?.accessToken) {
       throw new Error('Missing required accessToken for Space')
-    }
-
-    if (!environmentId) {
-      throw new Error('Missing required environment id')
     }
 
     const limitedAccessApi = authenticate(space?.accessToken, apiUrl)

--- a/packages/react/src/utils/initializeSpace.tsx
+++ b/packages/react/src/utils/initializeSpace.tsx
@@ -31,36 +31,27 @@ export const initializeSpace = async (
       throw new Error('Missing required publishable key')
     }
 
-    if (!environmentId) {
-      throw new Error('Missing required environment id')
-    }
-
     const limitedAccessApi = authenticate(publishableKey, apiUrl)
-    const createSpaceRequest = {
-      name,
-      autoConfigure: false,
-      environmentId,
-      ...spaceBody,
-      labels: ['embedded', ...(labels || [])],
-      ...(namespace ? { namespace } : {}),
-      ...(translationsPath ? { translationsPath } : {}),
-      ...(languageOverride ? { languageOverride } : {}),
-      metadata: {
-        ...metadata,
-        theme: themeConfig,
-        sidebarConfig: sidebarConfig ? sidebarConfig : { showSidebar: false },
-        userInfo,
-        spaceInfo,
-        ...(spaceBody?.metadata || {}),
-        ...(metadata || {}),
-      },
-    }
 
-    if (!workbook) {
-      createSpaceRequest.autoConfigure = true
-    }
     try {
-      space = await limitedAccessApi.spaces.create(createSpaceRequest)
+      space = await limitedAccessApi.spaces.create({
+        name,
+        autoConfigure: !workbook,
+        ...spaceBody,
+        labels: ['embedded', ...(labels || [])],
+        ...(environmentId !== undefined && { environmentId }),
+        ...(namespace ? { namespace } : {}),
+        ...(translationsPath ? { translationsPath } : {}),
+        ...(languageOverride ? { languageOverride } : {}),
+        metadata: {
+          theme: themeConfig,
+          sidebarConfig: sidebarConfig ? sidebarConfig : { showSidebar: false },
+          userInfo,
+          spaceInfo,
+          ...(spaceBody?.metadata || {}),
+          ...(metadata || {}),
+        },
+      })
     } catch (error) {
       throw new Error(`Failed to create space: ${getErrorMessage(error)}`)
     }

--- a/packages/vue/src/components/SpaceC.vue
+++ b/packages/vue/src/components/SpaceC.vue
@@ -171,7 +171,6 @@ export default {
       userInfo,
       handleCloseInstance
     } = props
-    const channel = `space.${spaceId}`
 
     const handleConfirm = () => {
       closeSpace?.onClose({})

--- a/packages/vue/src/utils/addSpaceInfo.ts
+++ b/packages/vue/src/utils/addSpaceInfo.ts
@@ -23,7 +23,7 @@ const addSpaceInfo = async (
     if (workbook) {
       const localWorkbook = await api.workbooks.create({
         spaceId,
-        environmentId,
+        ...(environmentId !== undefined && { environmentId }),
         ...workbook,
       })
 
@@ -33,7 +33,7 @@ const addSpaceInfo = async (
     }
 
     const updatedSpace = await api.spaces.update(spaceId, {
-      environmentId,
+      ...(environmentId !== undefined && { environmentId }),
       metadata: {
         theme: themeConfig,
         sidebarConfig: sidebarConfig || { showSidebar: false },

--- a/packages/vue/src/utils/getSpace.ts
+++ b/packages/vue/src/utils/getSpace.ts
@@ -5,20 +5,15 @@ import {
 import authenticate from './authenticate'
 import { Flatfile } from '@flatfile/api'
 
-type IWorkbook = Pick<
-  Flatfile.CreateWorkbookConfig,
-  'name' | 'sheets' | 'actions'
->
 const getSpace = async (
   spaceProps: ReusedSpaceWithAccessToken
 ): Promise<{
   space: any
-  workbook?: IWorkbook
+  workbook?: Flatfile.CreateWorkbookConfig
 }> => {
   const {
     space,
     apiUrl,
-    environmentId,
     spaceUrl = 'https://spaces.flatfile.com/',
   } = spaceProps
   let spaceResponse
@@ -29,10 +24,6 @@ const getSpace = async (
     }
     if (!space?.accessToken) {
       throw new Error('Missing required accessToken for Space')
-    }
-
-    if (!environmentId) {
-      throw new Error('Missing required environment id')
     }
 
     const limitedAccessApi = authenticate(space?.accessToken, apiUrl)
@@ -59,7 +50,7 @@ const getSpace = async (
           name: workbookResponse.data[0].name,
           sheets: workbookResponse.data[0].sheets,
           actions: workbookResponse.data[0].actions,
-        } as IWorkbook)
+        } as Flatfile.CreateWorkbookConfig)
       : undefined
 
     return { space: spaceResponse, workbook }

--- a/packages/vue/src/utils/initializeSpace.ts
+++ b/packages/vue/src/utils/initializeSpace.ts
@@ -10,7 +10,7 @@ export const initializeSpace = async (
   flatfileOptions: SimpleOnboarding
 ): Promise<{
   space: any
-  workbook?: Pick<Flatfile.CreateWorkbookConfig, 'name' | 'sheets' | 'actions'>
+  workbook?: Flatfile.CreateWorkbookConfig
 }> => {
   let space
   const {
@@ -28,10 +28,6 @@ export const initializeSpace = async (
   try {
     if (!publishableKey) {
       throw new Error('Missing required publishable key')
-    }
-
-    if (!environmentId) {
-      throw new Error('Missing required environment id')
     }
 
     const limitedAccessApi = authenticate(publishableKey, apiUrl)
@@ -53,7 +49,7 @@ export const initializeSpace = async (
 
     try {
       space = await limitedAccessApi.spaces.create({
-        environmentId,
+        ...(environmentId !== undefined && { environmentId }),
         ...spaceRequestBody,
       })
     } catch (error) {

--- a/packages/vue/src/utils/useInitializeSpace.ts
+++ b/packages/vue/src/utils/useInitializeSpace.ts
@@ -28,10 +28,6 @@ const useInitializeSpace = (flatfileOptions: SimpleOnboarding) => {
         throw new Error('Missing required publishable key')
       }
 
-      if (!environmentId) {
-        throw new Error('Missing required environment id')
-      }
-
       const limitedAccessApi = authenticate(publishableKey, apiUrl)
       const spaceRequestBody = {
         name,
@@ -50,7 +46,7 @@ const useInitializeSpace = (flatfileOptions: SimpleOnboarding) => {
 
       try {
         space.value = await limitedAccessApi.spaces.create({
-          environmentId,
+          ...(environmentId !== undefined && { environmentId }),
           ...spaceRequestBody,
         })
       } catch (error) {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
This makes removes environmentId as a required prop since it can be inferred from the credentials and is no longer required in the API endpoints used in the SDKs

## Tell code reviewer how and what to test:

### Notes:
This removes environmentId as a required prop, but does pass it along in case we get credentials in the future that has access to multiple environments.
