### PR TITLE
fix: onSubmit/onRecordHook not firing when usePortal is passed a `workbook` Issue 1136

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,14 +1,14 @@
+import { dts } from 'rollup-plugin-dts'
 import commonjs from '@rollup/plugin-commonjs'
+import css from 'rollup-plugin-import-css'
+import dotenv from 'dotenv'
 import json from '@rollup/plugin-json'
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
+import postcss from 'rollup-plugin-postcss'
 import resolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
 import url from '@rollup/plugin-url'
-import dotenv from 'dotenv'
-import { dts } from 'rollup-plugin-dts'
-import css from 'rollup-plugin-import-css'
-import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss'
 
 dotenv.config()
 
@@ -20,7 +20,11 @@ if (!PROD) {
 
 function commonPlugins(browser, umd = false) {
   return [
-    !umd ? peerDepsExternal() : null,
+    !umd
+      ? peerDepsExternal({
+          includeDependencies: true,
+        })
+      : null,
     json(),
     css(),
     resolve({ browser, preferBuiltins: !browser }),

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,14 +1,14 @@
-import { dts } from 'rollup-plugin-dts'
 import commonjs from '@rollup/plugin-commonjs'
-import css from 'rollup-plugin-import-css'
-import dotenv from 'dotenv'
 import json from '@rollup/plugin-json'
-import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-import postcss from 'rollup-plugin-postcss'
 import resolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
 import url from '@rollup/plugin-url'
+import dotenv from 'dotenv'
+import { dts } from 'rollup-plugin-dts'
+import css from 'rollup-plugin-import-css'
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
+import postcss from 'rollup-plugin-postcss'
 
 dotenv.config()
 
@@ -20,11 +20,7 @@ if (!PROD) {
 
 function commonPlugins(browser, umd = false) {
   return [
-    !umd
-      ? peerDepsExternal({
-          includeDependencies: true,
-        })
-      : null,
+    !umd ? peerDepsExternal() : null,
     json(),
     css(),
     resolve({ browser, preferBuiltins: !browser }),


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
This PR fixes `onSubmit` and `onRecordHook` failing to run when `usePortal` was passed a `workbook` instead of a `sheet`.

Closes https://github.com/FlatFilers/support-triage/issues/1136

## Tell code reviewer how and what to test:
Pass a workbook to `usePortal` and set `onRecordHook` and `onSubmit`. Both of these hook should run now.
```
usePortal({
      ...
      workbook, // <-- pass a workbook instead of a sheet
      onSubmit: async ({ job, sheet, event }) => {
        const data = await sheet.allData();
        console.log("onSubmit", data);
      },
      onRecordHook: (record) => {
        const firstName = record.get("firstName");
        console.log({ firstName });
        record.set("lastName", "Rock");
        return record;
      },
    });
  };
```
