### PR TITLE
Infer topics from listener

### DIFF
--- a/.changeset/early-guests-drum.md
+++ b/.changeset/early-guests-drum.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Adds functionality to infer which topics an agent should listen on

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,6 @@
     "ora": "^5.4.1",
     "prompts": "^2.4.2",
     "rc": "^1.2.8",
-    "remeda": "^0.0.35",
     "read-package-json": "^6.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-inject-process-env": "^1.3.1",


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Helps developers narrow the scope of their listeners by determining which topics their code is listening on and automatically narrowing the scope of their listener to that set.

## Tell code reviewer how and what to test:

1. Build the cli package locally
2. Deploy a listener with the local cli
a) Listening on "\*\*"
b) Listening on "<\<domain>>:\*\*"
c) Listening on "<\<domain>>:<\<event>>"
^ And/or any combination of the above.
3. Confirm in the new dash which topics were set for the deployed agent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated `@flatfile/listener` for enhanced deployment actions.
	- Improved agent selection logic during deployment.
- **Refactor**
	- Updated topic handling mechanism for deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->