### PR TITLE
feat: set acknowledge: true on Submit Action Job

### DIFF
--- a/.changeset/strong-adults-deny.md
+++ b/.changeset/strong-adults-deny.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Updates onSubmit action handlers to add acknowledge: true to the job

--- a/packages/react/src/utils/constants.ts
+++ b/packages/react/src/utils/constants.ts
@@ -1,4 +1,10 @@
-import { Flatfile } from '@flatfile/api'
+import { Flatfile, FlatfileClient } from '@flatfile/api'
+import {
+  JobHandler,
+  SheetHandler,
+  SimpleOnboarding,
+} from '@flatfile/embedded-utils'
+import { FlatfileEvent } from '@flatfile/listener'
 
 export const workbookOnSubmitAction = (sheetSlug?: string): Flatfile.Action => {
   const operation = sheetSlug
@@ -10,5 +16,48 @@ export const workbookOnSubmitAction = (sheetSlug?: string): Flatfile.Action => {
     label: 'Submit',
     description: 'Action for handling data inside of onSubmit',
     primary: true,
+  }
+}
+
+export const OnSubmitAction = (
+  onSubmit: SimpleOnboarding['onSubmit'],
+  onSubmitSettings: SimpleOnboarding['submitSettings']
+) => {
+  return async (event: FlatfileEvent) => {
+    const { jobId, spaceId, workbookId } = event.context
+    const FlatfileAPI = new FlatfileClient()
+    try {
+      await FlatfileAPI.jobs.ack(jobId, {
+        info: 'Starting job',
+        progress: 10,
+      })
+
+      const job = new JobHandler(jobId)
+      const { data: workbookSheets } = await FlatfileAPI.sheets.list({
+        workbookId,
+      })
+
+      // this assumes we are only allowing 1 sheet here (which we've talked about doing initially)
+      const sheet = new SheetHandler(workbookSheets[0].id)
+
+      if (onSubmit) {
+        await onSubmit({ job, sheet, event })
+      }
+
+      await FlatfileAPI.jobs.complete(jobId, {
+        outcome: {
+          acknowledge: true,
+          message: 'Submitting data is now complete!',
+        },
+      })
+      if (onSubmitSettings?.deleteSpaceAfterSubmit) {
+        await FlatfileAPI.spaces.archiveSpace(spaceId)
+      }
+    } catch (error: any) {
+      if (jobId) {
+        await FlatfileAPI.jobs.cancel(jobId)
+      }
+      console.log('Error:', error.stack)
+    }
   }
 }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Updates the Job Outcome for any `onSubmit` action to `acknowledge: true` so that they broadcast a `job:outcome-acknowledged` event. That way, users can listen for that event on specific jobs to close the importer! 

## Tell code reviewer how and what to test:
There is now an example in the `apps/react` app that closes the importer on the Workbook's onSubmit action as an example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced event handling across the application for improved performance and error management.
	- Streamlined form submission processes in various components for better user interaction.
	- Made significant modifications to imports and removed unused dependencies in the Workbook component.

- **New Features**
	- Implemented structured logging for event details to aid in troubleshooting and user support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->