### PR TITLE
Fix/explicitly add cron

### DIFF
--- a/.changeset/curly-maps-call.md
+++ b/.changeset/curly-maps-call.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Filter cron events out of wildcard subscription

--- a/packages/cli/src/x/actions/deploy.action.ts
+++ b/packages/cli/src/x/actions/deploy.action.ts
@@ -76,7 +76,9 @@ function findActiveTopics(allTopics: ListenerTopics[], client: any, topicsWithLi
   client.listeners?.forEach((listener: ListenerTopics[]) => {
     const listenerTopic = listener[0]
     if (listenerTopic === '**') {
-      allTopics.forEach(topic => topicsWithListeners.add(topic))
+      // Filter cron events out of '**' list - they must be added explicitly
+      const filteredTopics = allTopics.filter(event => !event.startsWith('cron:'))
+      filteredTopics.forEach(topic => topicsWithListeners.add(topic))
     } else if (listenerTopic.includes('**')) {
       const [prefix] = listenerTopic.split(':')
       allTopics.forEach(topic => { if (topic.split(':')[0] === prefix) topicsWithListeners.add(topic) })


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Ensure the wildcard ('**') match doesn't subscribe to all cron events, those must be added explicitly
Note 'cron:**' will still work, as this counts as explicit.

## Tell code reviewer how and what to test:

Deploy a listener with '**', then fetch the agent to look at the topics list.