### PR TITLE
feat: Adds `DefaultPage` To React and Resetting the Portal on Close

### DIFF
--- a/.changeset/angry-jobs-shake.md
+++ b/.changeset/angry-jobs-shake.md
@@ -2,4 +2,4 @@
 '@flatfile/listener': patch
 ---
 
-Adds unmount() to @flatfile/listener
+Adds `listener.unmount()` to @flatfile/listener

--- a/.changeset/angry-jobs-shake.md
+++ b/.changeset/angry-jobs-shake.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/listener': patch
+---
+
+Adds unmount() to @flatfile/listener

--- a/.changeset/heavy-mayflies-collect.md
+++ b/.changeset/heavy-mayflies-collect.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fixes bug where ISO dates were automatically converted to JS Dates

--- a/.changeset/mean-years-heal.md
+++ b/.changeset/mean-years-heal.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/listener': patch
+---
+
+Adds resetting Space on Close to @flatfile/react, adds DefaultPage to @flatfile/react

--- a/.changeset/swift-carrots-invent.md
+++ b/.changeset/swift-carrots-invent.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/embedded-utils': minor
+---
+
+Remove unused dependencies

--- a/.changeset/swift-carrots-invent.md
+++ b/.changeset/swift-carrots-invent.md
@@ -1,5 +1,0 @@
----
-'@flatfile/embedded-utils': minor
----
-
-Remove unused dependencies

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -94,7 +94,7 @@ const App = () => {
           },
         }}
       >
-        <Document config={document} />
+        <Document defaultPage={true} config={document} />
         <Workbook
           config={{
             ...workbook,
@@ -133,6 +133,7 @@ const App = () => {
             }}
           />
           <Sheet
+            // defaultPage={true}
             config={{
               ...workbook.sheets![0],
               slug: 'contacts4',

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -129,7 +129,7 @@ const App = () => {
             }}
           />
           <Sheet
-            // defaultPage={true}
+            defaultPage={true}
             config={{
               ...workbook.sheets![0],
               slug: 'contacts4',

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -16,10 +16,12 @@ import styles from './page.module.css'
 import { recordHook } from '@flatfile/plugin-record-hook'
 
 const App = () => {
-  const { open, openPortal, closePortal } = useFlatfile()
+  const { open, openPortal, closePortal, listener } = useFlatfile()
 
   const [label, setLabel] = useState('Rock')
-
+  const toggleOpen = () => {
+    open ? closePortal({ reset: false }) : openPortal()
+  }
   useListener((listener) => {
     listener.on('**', (event) => {
       console.log('FFApp useListener Event => ', {
@@ -42,7 +44,7 @@ const App = () => {
         const firstName = record.get('firstName')
         console.log({ firstName })
 
-        record.set('lastName', 'Rock')
+        record.set('lastName', 'Rocks')
         return record
       })
     )
@@ -74,13 +76,7 @@ const App = () => {
   return (
     <div className={styles.main}>
       <div className={styles.description}>
-        <button
-          onClick={() => {
-            open ? closePortal() : openPortal()
-          }}
-        >
-          {open ? 'CLOSE' : 'OPEN'} PORTAL
-        </button>
+        <button onClick={toggleOpen}>{open ? 'CLOSE' : 'OPEN'} PORTAL</button>
         <button onClick={() => setLabel('blue')}>blue listener</button>
         <button onClick={() => setLabel('green')}>green listener</button>
       </div>

--- a/apps/react/app/page.tsx
+++ b/apps/react/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
       publishableKey={PUBLISHABLE_KEY}
       config={{
         preload: true,
+        resetOnClose: true
       }}
     >
       <App />

--- a/apps/react/app/page.tsx
+++ b/apps/react/app/page.tsx
@@ -11,8 +11,7 @@ export default function Home() {
     <FlatfileProvider
       publishableKey={PUBLISHABLE_KEY}
       config={{
-        preload: true,
-        resetOnClose: true
+        preload: true
       }}
     >
       <App />

--- a/apps/react/app/sheet/App.tsx
+++ b/apps/react/app/sheet/App.tsx
@@ -25,6 +25,7 @@ const App = () => {
       </div>
 
       <Sheet
+        defaultPage={true}
         config={sheet}
         onRecordHook={(record) => {
           const email = record.get('email')

--- a/apps/react/next.config.js
+++ b/apps/react/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+    reactStrictMode: false,
+}
 
 module.exports = nextConfig

--- a/packages/listener/src/event-drivers/_EventDriver.ts
+++ b/packages/listener/src/event-drivers/_EventDriver.ts
@@ -21,6 +21,18 @@ export abstract class EventDriver {
   }
 
   /**
+   * Unmount an event handler
+   *
+   * @param handler
+   */
+  unmountEventHandler(handler: EventHandler): this {
+    if (this._handler === handler) {
+      this._handler = undefined
+    }
+    return this
+  }
+
+  /**
    * Dispatch an event
    *
    * @param e

--- a/packages/listener/src/flatfile.listener.ts
+++ b/packages/listener/src/flatfile.listener.ts
@@ -77,6 +77,14 @@ export class FlatfileListener extends EventHandler {
     return this
   }
 
+  /**
+   * Unmount this client from the Event Driver
+   */
+  unmount(driver: EventDriver) {
+    driver.unmountEventHandler(this)
+    return this
+  }
+
   fork() {
     return new FlatfileListener()
   }

--- a/packages/react/src/components/Document.tsx
+++ b/packages/react/src/components/Document.tsx
@@ -28,14 +28,12 @@ export const Document = (props: DocumentProps) => {
   const { config, defaultPage } = props
   const { updateDocument, setDefaultPage } = useContext(FlatfileContext)
 
-  const callback = useCallback(() => {
+  useDeepCompareEffect(() => {
     updateDocument(config)
     if (defaultPage) {
       setDefaultPage({ document: config.title })
     }
-  }, [config, updateDocument])
-
-  useDeepCompareEffect(callback, [config])
+  }, [config, defaultPage])
 
   return <></>
 }

--- a/packages/react/src/components/Document.tsx
+++ b/packages/react/src/components/Document.tsx
@@ -6,11 +6,12 @@ import { useDeepCompareEffect } from '../utils/useDeepCompareEffect'
 
 type DocumentProps = {
   config: Flatfile.DocumentConfig
+  defaultPage?: boolean
 }
 /**
  * `Document` component responsible for updating the document configuration within the Flatfile context.
  * It utilizes the `useDeepCompareEffect` hook to deeply compare the `config` prop changes and update the document accordingly.
- * 
+ *
  * @component
  * @example
  * const documentConfig = {
@@ -18,17 +19,20 @@ type DocumentProps = {
  *   body: "Example Body",
  * }
  * return <Document config={documentConfig} />
- * 
+ *
  * @param {DocumentProps} props - The props for the Document component.
  * @param {Flatfile.DocumentConfig} props.config - The configuration object for the document.
  */
 
 export const Document = (props: DocumentProps) => {
-  const { config } = props
-  const { updateDocument } = useContext(FlatfileContext)
+  const { config, defaultPage } = props
+  const { updateDocument, setDefaultPage } = useContext(FlatfileContext)
 
   const callback = useCallback(() => {
     updateDocument(config)
+    if (defaultPage) {
+      setDefaultPage({ document: config.title })
+    }
   }, [config, updateDocument])
 
   useDeepCompareEffect(callback, [config])

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -34,7 +34,7 @@ export const EmbeddedIFrameWrapper = (
   useEffect(() => {
     if (sessionSpace && iRef.current) {
       const targetOrigin = new URL(spacesUrl).origin
-
+      
       iRef.current.contentWindow?.postMessage(
         {
           flatfileEvent: {

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useContext, useRef, useEffect, JSX } from 'react'
+import React, {
+  useState,
+  useContext,
+  useRef,
+  useEffect,
+  JSX,
+  MutableRefObject,
+} from 'react'
 import { IFrameTypes } from '../types'
 import ConfirmModal from './ConfirmCloseModal'
 import FlatfileContext from './FlatfileContext'
@@ -8,10 +15,10 @@ import { CloseButton } from './CloseButton'
 export const EmbeddedIFrameWrapper = (
   props: Partial<IFrameTypes> & {
     handleCloseInstance: () => void
+    iRef: MutableRefObject<HTMLIFrameElement | null>
   }
 ): JSX.Element => {
   const { open, sessionSpace } = useContext(FlatfileContext)
-  const iRef = useRef<HTMLIFrameElement | null>(null)
 
   const [showExitWarnModal, setShowExitWarnModal] = useState(false)
 
@@ -25,6 +32,7 @@ export const EmbeddedIFrameWrapper = (
     exitSecondaryButtonText = 'No, stay',
     displayAsModal = true,
     handleCloseInstance,
+    iRef,
     preload = true,
     spaceUrl,
   } = props
@@ -34,27 +42,31 @@ export const EmbeddedIFrameWrapper = (
   useEffect(() => {
     if (sessionSpace && iRef.current) {
       const targetOrigin = new URL(spacesUrl).origin
-      
-      iRef.current.contentWindow?.postMessage(
-        {
-          flatfileEvent: {
-            topic: 'portal:initialize',
-            payload: {
-              status: 'complete',
-              spaceUrl: `${targetOrigin}/space/${
-                sessionSpace.space.id
-              }?token=${encodeURIComponent(sessionSpace.space.accessToken)}`,
-              initialResources: sessionSpace,
+      if (sessionSpace.space?.id && sessionSpace.space?.accessToken) {
+        iRef.current.contentWindow?.postMessage(
+          {
+            flatfileEvent: {
+              topic: 'portal:initialize',
+              payload: {
+                status: 'complete',
+                spaceUrl: `${targetOrigin}/space/${
+                  sessionSpace.space.id
+                }?token=${encodeURIComponent(sessionSpace.space.accessToken)}`,
+                initialResources: sessionSpace,
+              },
             },
           },
-        },
-        targetOrigin
-      )
+          targetOrigin
+        )
+      }
     }
   }, [sessionSpace])
 
   const spaceLink = sessionSpace?.space?.guestLink || null
-
+  const openVisible = (open: boolean): React.CSSProperties => ({
+    opacity: open ? 1 : 0,
+    pointerEvents: open ? 'all' : 'none',
+  })
   return (
     <div
       className={`flatfile_iframe-wrapper ${
@@ -62,7 +74,7 @@ export const EmbeddedIFrameWrapper = (
       }`}
       style={{
         ...getContainerStyles(displayAsModal),
-        display: open ? 'flex' : 'none',
+        ...openVisible(open),
       }}
       data-testid="space-contents"
     >
@@ -91,9 +103,7 @@ export const EmbeddedIFrameWrapper = (
           src={preload ? preloadUrl : spaceLink}
           style={{
             ...getIframeStyles(iframeStyles!),
-            ...(preload
-              ? { display: open ? 'block' : 'none' }
-              : { display: 'block' }),
+            ...(preload ? openVisible(open) : { opacity: 1 }),
           }}
         />
       )}

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -48,6 +48,8 @@ export interface FlatfileContextType {
   createSpace: any
   setCreateSpace: (config: any) => void
   updateSpace: (config: any) => void
+  defaultPage: undefined
+  setDefaultPage: (object: any) => void
 }
 
 export const FlatfileContext = createContext<FlatfileContextType>({
@@ -70,6 +72,8 @@ export const FlatfileContext = createContext<FlatfileContextType>({
   createSpace: undefined,
   setCreateSpace: () => {},
   updateSpace: () => {},
+  defaultPage: undefined,
+  setDefaultPage: () => {}
 })
 export const useFlatfileInternal = () => useContext(FlatfileContext)
 export default FlatfileContext

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -1,7 +1,7 @@
 import { Flatfile } from '@flatfile/api'
-import { ISpace } from '@flatfile/embedded-utils'
 import FlatfileListener from '@flatfile/listener'
 import { createContext, useContext } from 'react'
+import { IFrameTypes, ClosePortalOptions } from '../types'
 
 type CreateNewSpace = Partial<Flatfile.SpaceConfig>
 type ReUseSpace = Partial<Flatfile.SpaceConfig> & {
@@ -33,11 +33,11 @@ export interface FlatfileContextType {
   setOpen: (open: boolean) => void
   space?: CreateNewSpace | ReUseSpace
   sessionSpace?: any
-  setSessionSpace: (space: any) => void
+  setSessionSpace: (space: any | null) => void
   listener: FlatfileListener
   setListener: (listener: FlatfileListener) => void
   accessToken?: string
-  setAccessToken: (accessToken: string) => void
+  setAccessToken: (accessToken?: string | null) => void
   addSheet: (config: any) => void
   updateSheet: (
     sheetSlug: string,
@@ -50,6 +50,8 @@ export interface FlatfileContextType {
   updateSpace: (config: any) => void
   defaultPage: undefined
   setDefaultPage: (object: any) => void
+  resetSpace: (options?: ClosePortalOptions) => void
+  config?: IFrameTypes
 }
 
 export const FlatfileContext = createContext<FlatfileContextType>({
@@ -73,7 +75,9 @@ export const FlatfileContext = createContext<FlatfileContextType>({
   setCreateSpace: () => {},
   updateSpace: () => {},
   defaultPage: undefined,
-  setDefaultPage: () => {}
+  setDefaultPage: () => {},
+  resetSpace: () => {},
+  config: undefined,
 })
 export const useFlatfileInternal = () => useContext(FlatfileContext)
 export default FlatfileContext

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -27,6 +27,8 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     space: Flatfile.SpaceConfig
   }>(DEFAULT_CREATE_SPACE)
 
+  const [defaultPage, setDefaultPage] = useState<any>(null)
+
   const addSheet = (newSheet: Flatfile.SheetConfig) => {
     setCreateSpace((prevSpace) => {
       // Check if the sheet already exists
@@ -154,6 +156,8 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
         createSpace,
         setCreateSpace,
         updateSpace,
+        defaultPage,
+        setDefaultPage,
       }}
     >
       {children}

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -12,6 +12,13 @@ const configDefaults: IFrameTypes = {
   resetOnClose: true,
 }
 
+interface SESSION_SPACE
+  extends Omit<Flatfile.Space, 'createdAt' | 'updatedAt' | 'upgradedAt'> {
+  createdAt: string
+  updatedAt: string
+  upgradedAt: string
+}
+
 export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
   children,
   publishableKey,
@@ -25,7 +32,9 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
   >(accessToken)
   const [listener, setListener] = useState(new FlatfileListener())
   const [open, setOpen] = useState<boolean>(false)
-  const [sessionSpace, setSessionSpace] = useState<any>(null)
+  const [sessionSpace, setSessionSpace] = useState<
+    { space: SESSION_SPACE } | undefined
+  >(undefined)
 
   const [createSpace, setCreateSpace] = useState<{
     document: Flatfile.DocumentConfig | undefined
@@ -139,19 +148,20 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
 
     if (reset ?? FLATFILE_PROVIDER_CONFIG.resetOnClose) {
       setAccessToken(null)
-      setSessionSpace(null)
+      setSessionSpace(undefined)
 
       const spacesUrl =
         FLATFILE_PROVIDER_CONFIG.spaceUrl || 'https://platform.flatfile.com/s'
       const preloadUrl = `${spacesUrl}/space-init`
 
       const spaceLink = sessionSpace?.space?.guestLink || null
-
+      const iFrameSrc = FLATFILE_PROVIDER_CONFIG.preload
+        ? preloadUrl
+        : spaceLink
+      if (iFrameSrc) {
+        iframe?.current?.setAttribute('src', iFrameSrc)
+      }
       // Works but only after the iframe is visible
-      iframe?.current?.setAttribute(
-        'src',
-        FLATFILE_PROVIDER_CONFIG.preload ? preloadUrl : spaceLink
-      )
     }
   }
 

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import FlatfileContext, { DEFAULT_CREATE_SPACE } from './FlatfileContext'
 import FlatfileListener, { Browser } from '@flatfile/listener'
 import { Flatfile } from '@flatfile/api'
@@ -33,7 +33,25 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     space: Flatfile.SpaceConfig
   }>(DEFAULT_CREATE_SPACE)
 
-  const [defaultPage, setDefaultPage] = useState<any>(null)
+  const [defaultPage, setDefaultPageRaw] = useState<any>(undefined)
+
+  const setDefaultPage = useCallback(
+    (incomingDefaultPage: any) => {
+      if (defaultPage === undefined) {
+        setDefaultPageRaw(incomingDefaultPage)
+      } else {
+        console.warn(
+          `Attempt to set multiple default pages detected. Only one default page can be set per space. Current default page: ${JSON.stringify(
+            defaultPage
+          )}, Attempted new default page: ${JSON.stringify(
+            incomingDefaultPage
+          )}`
+        )
+      }
+    },
+    [defaultPage]
+  )
+
   const iframe = useRef<HTMLIFrameElement | null>(null)
 
   const FLATFILE_PROVIDER_CONFIG = { ...config, ...configDefaults }

--- a/packages/react/src/components/Sheet.tsx
+++ b/packages/react/src/components/Sheet.tsx
@@ -17,6 +17,7 @@ type SheetProps = {
   onSubmit?: SimpleOnboarding['onSubmit']
   submitSettings?: SimpleOnboarding['submitSettings']
   onRecordHook?: SimpleOnboarding['onRecordHook']
+  defaultPage?: boolean
 }
 /**
  * `Sheet` component for Flatfile integration.
@@ -62,8 +63,9 @@ type SheetProps = {
  */
 
 export const Sheet = (props: SheetProps) => {
-  const { config, onRecordHook, onSubmit, submitSettings } = props
-  const { addSheet, updateWorkbook, createSpace } = useContext(FlatfileContext)
+  const { config, onRecordHook, onSubmit, submitSettings, defaultPage } = props
+  const { addSheet, updateWorkbook, createSpace, setDefaultPage } =
+    useContext(FlatfileContext)
 
   const callback = useCallback(() => {
     // Manage actions immutably
@@ -76,6 +78,13 @@ export const Sheet = (props: SheetProps) => {
       })
     }
     addSheet(config)
+    if (defaultPage) {
+      setDefaultPage({
+        workbook: {
+          sheet: config.slug,
+        },
+      })
+    }
   }, [config, createSpace, addSheet, updateWorkbook, onSubmit])
 
   useDeepCompareEffect(callback, [config])

--- a/packages/react/src/components/Sheet.tsx
+++ b/packages/react/src/components/Sheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { Flatfile } from '@flatfile/api'
 import { useContext } from 'react'
 import FlatfileContext from './FlatfileContext'
@@ -67,7 +67,7 @@ export const Sheet = (props: SheetProps) => {
   const { addSheet, updateWorkbook, createSpace, setDefaultPage } =
     useContext(FlatfileContext)
 
-  const callback = useCallback(() => {
+  useDeepCompareEffect(() => {
     // Manage actions immutably
     if (onSubmit) {
       updateWorkbook({
@@ -85,9 +85,7 @@ export const Sheet = (props: SheetProps) => {
         },
       })
     }
-  }, [config, createSpace, addSheet, updateWorkbook, onSubmit])
-
-  useDeepCompareEffect(callback, [config])
+  }, [config, defaultPage])
 
   if (onRecordHook) {
     usePlugin(

--- a/packages/react/src/components/Space.tsx
+++ b/packages/react/src/components/Space.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useContext } from 'react'
 import type { Flatfile } from '@flatfile/api'
 import FlatfileContext from './FlatfileContext'
 import { useDeepCompareEffect } from '../utils/useDeepCompareEffect'
@@ -36,14 +36,12 @@ export const Space = (props: SpaceProps) => {
   const { config, id, children } = props
   const { updateSpace } = useContext(FlatfileContext)
 
-  const callback = useCallback(() => {
+  useDeepCompareEffect(() => {
     updateSpace({
       ...(config || {}),
       id,
     })
-  }, [config, updateSpace])
-
-  useDeepCompareEffect(callback, [config])
+  }, [config])
 
   return <>{children}</>
 }

--- a/packages/react/src/components/Workbook.tsx
+++ b/packages/react/src/components/Workbook.tsx
@@ -1,5 +1,5 @@
 import FlatfileContext from './FlatfileContext'
-import React, { useCallback, useContext } from 'react'
+import React, { useContext } from 'react'
 import { type Flatfile } from '@flatfile/api'
 import { useDeepCompareEffect } from '../utils/useDeepCompareEffect'
 import { TRecordDataWithLinks, TPrimitive } from '@flatfile/hooks'
@@ -73,7 +73,7 @@ export const Workbook = (props: WorkbookProps) => {
   const { updateWorkbook, createSpace } = useContext(FlatfileContext)
   // Accept a workbook onSubmit function and add it to the workbook actions
 
-  const callback = useCallback(() => {
+  useDeepCompareEffect(() => {
     // adds workbook action if onSubmit is passed along
     updateWorkbook(
       onSubmit
@@ -83,9 +83,7 @@ export const Workbook = (props: WorkbookProps) => {
           }
         : config
     )
-  }, [config, onSubmit])
-
-  useDeepCompareEffect(callback, [config])
+  }, [config])
 
   usePlugin(
     (client) => {

--- a/packages/react/src/components/_tests_/Document.spec.tsx
+++ b/packages/react/src/components/_tests_/Document.spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { Document } from '../Document'
 import FlatfileContext from '../FlatfileContext'
 import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect'
-import { MockFlatfileProviderValue } from './FlatfileProvider.spec'
+import { FlatfileProviderValue } from './FlatfileProvider.spec'
 
 jest.mock('../../utils/useDeepCompareEffect', () => ({
   useDeepCompareEffect: jest.fn(),
@@ -27,7 +27,7 @@ describe('Document', () => {
     render(
       <FlatfileContext.Provider
         value={{
-          ...MockFlatfileProviderValue,
+          ...FlatfileProviderValue,
           updateDocument: mockUpdateDocument,
         }}
       >
@@ -44,7 +44,7 @@ describe('Document', () => {
     const { rerender } = render(
       <FlatfileContext.Provider
         value={{
-          ...MockFlatfileProviderValue,
+          ...FlatfileProviderValue,
           updateDocument: mockUpdateDocument,
         }}
       >
@@ -56,7 +56,7 @@ describe('Document', () => {
     rerender(
       <FlatfileContext.Provider
         value={{
-          ...MockFlatfileProviderValue,
+          ...FlatfileProviderValue,
           updateDocument: mockUpdateDocument,
         }}
       >

--- a/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
+++ b/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
@@ -1,11 +1,14 @@
 import React, { useContext } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { FlatfileProvider } from '../FlatfileProvider'
-import FlatfileContext, { FlatfileContextType } from '../FlatfileContext'
+import FlatfileContext, {
+  DEFAULT_CREATE_SPACE,
+  FlatfileContextType,
+} from '../FlatfileContext'
 import fetchMock from 'jest-fetch-mock'
 import FlatfileListener from '@flatfile/listener'
 
-export const MockFlatfileProviderValue: FlatfileContextType = {
+export const FlatfileProviderValue: FlatfileContextType = {
   updateDocument: jest.fn(),
   apiUrl: '',
   open: false,
@@ -17,9 +20,12 @@ export const MockFlatfileProviderValue: FlatfileContextType = {
   addSheet: jest.fn(),
   updateSheet: jest.fn(),
   updateWorkbook: jest.fn(),
-  createSpace: undefined,
+  createSpace: DEFAULT_CREATE_SPACE,
   setCreateSpace: jest.fn(),
   updateSpace: jest.fn(),
+  defaultPage: undefined,
+  setDefaultPage: jest.fn(),
+  resetSpace: jest.fn(),
 }
 
 fetchMock.enableMocks()

--- a/packages/react/src/components/_tests_/Sheet.spec.tsx
+++ b/packages/react/src/components/_tests_/Sheet.spec.tsx
@@ -1,31 +1,11 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { Sheet } from '../Sheet'
-import FlatfileContext, {
-  DEFAULT_CREATE_SPACE,
-  FlatfileContextType,
-} from '../FlatfileContext'
+import FlatfileContext from '../FlatfileContext'
 import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect'
 import { workbookOnSubmitAction } from '../../utils/constants'
-import FlatfileListener from '@flatfile/listener'
 import { Flatfile } from '@flatfile/api'
-
-const MockFlatfileProviderValue: FlatfileContextType = {
-  updateDocument: jest.fn(),
-  apiUrl: '',
-  open: false,
-  setOpen: jest.fn(),
-  setSessionSpace: jest.fn(),
-  listener: new FlatfileListener(),
-  setListener: jest.fn(),
-  setAccessToken: jest.fn(),
-  addSheet: jest.fn(),
-  updateSheet: jest.fn(),
-  updateWorkbook: jest.fn(),
-  createSpace: DEFAULT_CREATE_SPACE,
-  setCreateSpace: jest.fn(),
-  updateSpace: jest.fn(),
-}
+import { FlatfileProviderValue } from './FlatfileProvider.spec'
 
 jest.mock('../../utils/useDeepCompareEffect', () => ({
   useDeepCompareEffect: jest.fn(),
@@ -63,7 +43,7 @@ describe('Sheet', () => {
     render(
       <FlatfileContext.Provider
         value={{
-          ...MockFlatfileProviderValue,
+          ...FlatfileProviderValue,
           addSheet: mockUpdateSheet,
         }}
       >
@@ -84,7 +64,7 @@ describe('Sheet', () => {
     render(
       <FlatfileContext.Provider
         value={{
-          ...MockFlatfileProviderValue,
+          ...FlatfileProviderValue,
           updateWorkbook: mockUpdateWorkbook,
           addSheet: mockUpdateSheet,
         }}

--- a/packages/react/src/components/_tests_/Space.spec.tsx
+++ b/packages/react/src/components/_tests_/Space.spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { Space } from '../Space'
 import FlatfileContext from '../FlatfileContext'
 import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect'
-import { MockFlatfileProviderValue } from './FlatfileProvider.spec'
+import { FlatfileProviderValue } from './FlatfileProvider.spec'
 jest.mock('../../utils/useDeepCompareEffect', () => ({
   useDeepCompareEffect: jest.fn(),
 }))
@@ -25,7 +25,7 @@ describe('Space', () => {
   it('calls updateSpace with config on initial render', () => {
     render(
       <FlatfileContext.Provider
-        value={{ ...MockFlatfileProviderValue, updateSpace: mockUpdateSpace }}
+        value={{ ...FlatfileProviderValue, updateSpace: mockUpdateSpace }}
       >
         <Space config={MockSpaceConfig} />
       </FlatfileContext.Provider>
@@ -38,7 +38,7 @@ describe('Space', () => {
     const newConfig = { ...MockSpaceConfig, name: 'New Test Area' }
     const { rerender } = render(
       <FlatfileContext.Provider
-        value={{ ...MockFlatfileProviderValue, updateSpace: mockUpdateSpace }}
+        value={{ ...FlatfileProviderValue, updateSpace: mockUpdateSpace }}
       >
         <Space config={MockSpaceConfig} />
       </FlatfileContext.Provider>
@@ -46,7 +46,7 @@ describe('Space', () => {
 
     rerender(
       <FlatfileContext.Provider
-        value={{ ...MockFlatfileProviderValue, updateSpace: mockUpdateSpace }}
+        value={{ ...FlatfileProviderValue, updateSpace: mockUpdateSpace }}
       >
         <Space config={newConfig} />
       </FlatfileContext.Provider>

--- a/packages/react/src/components/_tests_/Workbook.spec.tsx
+++ b/packages/react/src/components/_tests_/Workbook.spec.tsx
@@ -4,21 +4,11 @@ import { Workbook } from '../Workbook'
 import FlatfileContext, { FlatfileContextType } from '../FlatfileContext'
 import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect'
 import { workbookOnSubmitAction } from '../../utils/constants'
-import FlatfileListener from '@flatfile/listener'
 import { Flatfile } from '@flatfile/api'
+import { FlatfileProviderValue } from './FlatfileProvider.spec'
 
 const MockFlatfileProviderValue: FlatfileContextType = {
-  updateDocument: jest.fn(),
-  apiUrl: '',
-  open: false,
-  setOpen: jest.fn(),
-  setSessionSpace: jest.fn(),
-  listener: new FlatfileListener(),
-  setListener: jest.fn(),
-  setAccessToken: jest.fn(),
-  addSheet: jest.fn(),
-  updateSheet: jest.fn(),
-  updateWorkbook: jest.fn(),
+  ...FlatfileProviderValue,
   createSpace: {
     document: undefined,
     workbook: {
@@ -34,8 +24,6 @@ const MockFlatfileProviderValue: FlatfileContextType = {
       },
     },
   },
-  setCreateSpace: jest.fn(),
-  updateSpace: jest.fn(),
 }
 
 jest.mock('../../utils/useDeepCompareEffect', () => ({

--- a/packages/react/src/components/embeddedStyles.tsx
+++ b/packages/react/src/components/embeddedStyles.tsx
@@ -6,9 +6,9 @@ export const getIframeStyles = (styles: React.CSSProperties) => {
       width: '100%',
       height: '750px',
       borderWidth: 0,
-      borderRadius: '20px',
       background: '#fff',
-      padding: '16px',
+      boxShadow:
+        '0px 4px 6px rgba(154, 160, 185, 0.05), 0px 1px 3px rgba(166, 173, 201, 0.3)',
     }
   )
 }
@@ -22,7 +22,7 @@ export const getContainerStyles = (isModal: boolean): React.CSSProperties => {
       top: 0,
       left: 0,
       zIndex: 1000,
-      backgroundColor: 'rgba(0,0,0,0.2)',
+      backgroundColor: 'rgba(0, 0, 0, 0.1)',
       display: 'flex',
       padding: '50px',
     }

--- a/packages/react/src/components/style.scss
+++ b/packages/react/src/components/style.scss
@@ -45,6 +45,7 @@
   font-size: var(--size-base);
   line-height: 1.5;
   margin: 0;
+  transition: 0.25s ease-in-out;
 }
 
 .flatfile-close-button {
@@ -60,10 +61,9 @@
   border-radius: 100%;
   cursor: pointer;
   border: none;
-  background: red;
+  background: rgb(29, 31, 74);
   box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.5);
-  animation: glow 1.5s linear infinite alternate;
-  transition: box-shadow 0.3s ease;
+  transition: 0.25s ease-in-out;
 
   &:hover {
     box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.8);

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -2,6 +2,37 @@ import { useContext } from 'react'
 import FlatfileContext from '../components/FlatfileContext'
 import { getSpace } from '../utils/getSpace'
 import { createSpaceInternal } from '../utils/createSpaceInternal'
+import { FlatfileClient } from '@flatfile/api'
+
+const findDefaultPage = (createdSpace: any, defaultPage: any) => {
+  if (defaultPage.document) {
+    const document = createdSpace.documents.find(
+      (d: any) => d.title === defaultPage.document
+    )
+    return {
+      documentId: document.id,
+    }
+  }
+  if (defaultPage.workbook) {
+    if (defaultPage.workbook.sheet) {
+      const sheet = createdSpace.workbooks[0].sheets.find(
+        (s: any) => s.slug === defaultPage.workbook.sheet
+      )
+      return {
+        workbook: {
+          workbookId: createdSpace.workbooks[0].id,
+          sheetId: sheet.id,
+        },
+      }
+    }
+    return {
+      workbook: {
+        workbookId: createdSpace.workbooks[0].id,
+      },
+    }
+  }
+  return undefined
+}
 
 export const useFlatfile: () => {
   openPortal: () => void
@@ -27,12 +58,18 @@ export const useFlatfile: () => {
     accessToken,
     setAccessToken,
     createSpace,
+    defaultPage,
   } = context
 
   const handleCreateSpace = async () => {
     if (!publishableKey) {
       return
     }
+
+    /* `const defaultPage = true` is initializing a constant variable `defaultPage` with a boolean
+    value of `true`. This variable is then used in the code to conditionally execute certain logic
+    based on its value. */
+    // const defaultPage = true
 
     // autoConfigure if no workbook or workbook.sheets are provided as they should be handled in the listener space:configure event
     const autoConfigure = !(createSpace.workbook && createSpace.workbook.sheets)
@@ -43,10 +80,33 @@ export const useFlatfile: () => {
       workbook: createSpace.workbook,
       document: createSpace.document,
     })
-    setAccessToken(createdSpace.space.accessToken)
-    setSessionSpace(createdSpace)
+    console.log({ createdSpace })
+
     // A bit of a hack to wire up the Flatfile API key to the window object for internal client side @flatfile/api usage
     ;(window as any).CROSSENV_FLATFILE_API_KEY = createdSpace.space.accessToken
+
+    const defaultPageDetails = findDefaultPage(createdSpace, defaultPage)
+    if (defaultPageDetails) {
+      const api = new FlatfileClient()
+      // const { documents } = createdSpace
+      const updatedSpace = await api.spaces.update(createdSpace.space.id, {
+        metadata: {
+          ...createdSpace.space.metadata,
+          sidebarConfig: {
+            defaultPage: defaultPageDetails,
+          },
+        },
+      })
+      console.log({ updatedSpace })
+      createdSpace.space.metadata.sidebarConfig = {
+        ...createdSpace.space.metadata.sidebarConfig,
+        defaultPage: defaultPageDetails,
+      }
+    }
+
+    setAccessToken(createdSpace.space.accessToken)
+
+    setSessionSpace(createdSpace)
   }
 
   const handleReUseSpace = async () => {

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -3,6 +3,7 @@ import FlatfileContext from '../components/FlatfileContext'
 import { getSpace } from '../utils/getSpace'
 import { createSpaceInternal } from '../utils/createSpaceInternal'
 import { FlatfileClient } from '@flatfile/api'
+import { ClosePortalOptions } from '../types'
 
 const findDefaultPage = (createdSpace: any, defaultPage: any) => {
   if (defaultPage.document) {
@@ -36,7 +37,7 @@ const findDefaultPage = (createdSpace: any, defaultPage: any) => {
 
 export const useFlatfile: () => {
   openPortal: () => void
-  closePortal: () => void
+  closePortal: (options?: ClosePortalOptions) => void
   open: boolean
   setListener: (listener: any) => void
   listener: any
@@ -59,18 +60,14 @@ export const useFlatfile: () => {
     setAccessToken,
     createSpace,
     defaultPage,
+    resetSpace,
   } = context
+  ;(window as any).CROSSENV_FLATFILE_API_URL = apiUrl
 
   const handleCreateSpace = async () => {
     if (!publishableKey) {
       return
     }
-
-    /* `const defaultPage = true` is initializing a constant variable `defaultPage` with a boolean
-    value of `true`. This variable is then used in the code to conditionally execute certain logic
-    based on its value. */
-    // const defaultPage = true
-
     // autoConfigure if no workbook or workbook.sheets are provided as they should be handled in the listener space:configure event
     const autoConfigure = !(createSpace.workbook && createSpace.workbook.sheets)
     const { data: createdSpace } = await createSpaceInternal({
@@ -80,39 +77,35 @@ export const useFlatfile: () => {
       workbook: createSpace.workbook,
       document: createSpace.document,
     })
-    console.log({ createdSpace })
-
     // A bit of a hack to wire up the Flatfile API key to the window object for internal client side @flatfile/api usage
     ;(window as any).CROSSENV_FLATFILE_API_KEY = createdSpace.space.accessToken
 
     const defaultPageDetails = findDefaultPage(createdSpace, defaultPage)
     if (defaultPageDetails) {
       const api = new FlatfileClient()
-      // const { documents } = createdSpace
       const updatedSpace = await api.spaces.update(createdSpace.space.id, {
         metadata: {
           ...createdSpace.space.metadata,
           sidebarConfig: {
+            ...createdSpace.space.metadata.sidebarConfig,
             defaultPage: defaultPageDetails,
           },
         },
       })
-      console.log({ updatedSpace })
+
       createdSpace.space.metadata.sidebarConfig = {
         ...createdSpace.space.metadata.sidebarConfig,
-        defaultPage: defaultPageDetails,
+        defaultPage: updatedSpace.data.metadata.sidebarConfig.defaultPage,
       }
     }
 
     setAccessToken(createdSpace.space.accessToken)
-
     setSessionSpace(createdSpace)
   }
 
   const handleReUseSpace = async () => {
     if (accessToken && 'id' in createSpace.space) {
       createSpace.space.accessToken = accessToken
-      // TODO: Do we want to update the Space metadata / documents here if they pass that information? Feels like a no.
       const { data: reUsedSpace } = await getSpace({
         space: createSpace.space,
         apiUrl,
@@ -130,15 +123,14 @@ export const useFlatfile: () => {
   const openPortal = () => {
     if (publishableKey && !accessToken) {
       handleCreateSpace()
-    } else if (accessToken) {
+    } else if (accessToken && !publishableKey) {
       handleReUseSpace()
     }
     setOpen(true)
   }
 
-  const closePortal = () => {
-    setOpen(false)
-    // TODO: Do we want to do any cleanup / remove the iFrame/listener from the DOM?
+  const closePortal = (options?: ClosePortalOptions) => {
+    resetSpace(options)
   }
 
   return {

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -6,6 +6,7 @@ import { FlatfileClient } from '@flatfile/api'
 import { ClosePortalOptions } from '../types'
 
 const findDefaultPage = (createdSpace: any, defaultPage: any) => {
+  if (!defaultPage) return
   if (defaultPage.document) {
     const document = createdSpace.documents.find(
       (d: any) => d.title === defaultPage.document
@@ -62,7 +63,6 @@ export const useFlatfile: () => {
     defaultPage,
     resetSpace,
   } = context
-  ;(window as any).CROSSENV_FLATFILE_API_URL = apiUrl
 
   const handleCreateSpace = async () => {
     if (!publishableKey) {
@@ -121,6 +121,7 @@ export const useFlatfile: () => {
   }
 
   const openPortal = () => {
+    ;(window as any).CROSSENV_FLATFILE_API_URL = apiUrl
     if (publishableKey && !accessToken) {
       handleCreateSpace()
     } else if (accessToken && !publishableKey) {
@@ -132,6 +133,7 @@ export const useFlatfile: () => {
   const closePortal = (options?: ClosePortalOptions) => {
     resetSpace(options)
   }
+
 
   return {
     openPortal,

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -4,6 +4,7 @@ import { getSpace } from '../utils/getSpace'
 import { createSpaceInternal } from '../utils/createSpaceInternal'
 import { FlatfileClient } from '@flatfile/api'
 import { ClosePortalOptions } from '../types'
+import { convertDatesToISO } from '../utils/convertDatesToISO'
 
 const findDefaultPage = (createdSpace: any, defaultPage: any) => {
   if (!defaultPage) return
@@ -116,7 +117,7 @@ export const useFlatfile: () => {
         setAccessToken(reUsedSpace.accessToken)
       }
 
-      setSessionSpace({ space: reUsedSpace })
+      setSessionSpace({ space: convertDatesToISO(reUsedSpace) })
     }
   }
 

--- a/packages/react/src/types/iFrameProps.ts
+++ b/packages/react/src/types/iFrameProps.ts
@@ -12,5 +12,5 @@ export type IFrameTypes = Partial<
     | 'displayAsModal'
     | 'closeSpace'
     | 'spaceUrl'
-  > & { preload?: boolean }
+  > & { preload?: boolean; resetOnClose?: boolean }
 >

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -2,3 +2,7 @@ export * from './IReactInitSpaceProps'
 export * from './IReactSpaceProps'
 export * from './iFrameProps'
 export * from './IFlatfileProvider'
+
+export type ClosePortalOptions = {
+  reset?: boolean
+}

--- a/packages/react/src/utils/convertDatesToISO.ts
+++ b/packages/react/src/utils/convertDatesToISO.ts
@@ -1,0 +1,16 @@
+export function convertDatesToISO(obj: any): any {
+  if (obj instanceof Date) {
+    return obj.toISOString();
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(convertDatesToISO);
+  }
+  if (typeof obj === 'object' && obj !== null) {
+    const newObj: { [key: string]: any } = {};
+    for (const key of Object.keys(obj)) {
+      newObj[key] = convertDatesToISO(obj[key]);
+    }
+    return newObj;
+  }
+  return obj;
+}


### PR DESCRIPTION
### Adds setting defaultPage to React Components:

You can now add defaultPage={true} to any Document or Sheet in the FlatfileProvider and it will launch the Space going to that Resource. 

Here's the syntax:
```tsx
      <Space>
        <Document defaultPage={true} config={document} />

        OR

        <Sheet defaultPage={true} config={sheetConfig} />
      </Space>
```

### Adds a configuration options to easily reset the Portal Space on when closing the Portal.
- `resetOnClose: true` to `FlatfileProvider` will reset the Space on Close for the the Close X box and the `closePortal()` helper function.
```tsx
    <FlatfileProvider
      publishableKey={PUBLISHABLE_KEY}
      config={{
        resetOnClose: false
      }}
    >
      <App />
    </FlatfileProvider>
```
- You can also override that setting by passing `closePortal({ reset: true })` and it will also reset the Portal 
```tsx
const App = () => {
  const { open, openPortal, closePortal } = useFlatfile()
  const toggleOpen = () => {
    open ? closePortal({ reset: false }) : openPortal()
  }
  ...
}
```
- The default is now to reset the Space on closing the Portal.

### Some cleanup here:
- Handle postMessage better (it was firing events to the listener twice!)
- Adds `listener.unmount()`

## Fixes bug with ISO Dates converting to JS Dates and stoping the preloading from working properly

Todos: 
- [ ] Throw an error message if the defaultPage is added to more than 1 component.