### PR TITLE
feat: check if context is ready before triggerin openPortal()

### DIFF
--- a/.changeset/fair-zebras-smash.md
+++ b/.changeset/fair-zebras-smash.md
@@ -1,6 +1,5 @@
 ---
 '@flatfile/react': patch
-'flatfile': patch
 ---
 
 Adds more control over Opening Portal

--- a/.changeset/fair-zebras-smash.md
+++ b/.changeset/fair-zebras-smash.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/react': patch
+'flatfile': patch
+---
+
+Adds more control over Opening Portal

--- a/.changeset/hungry-ravens-buy.md
+++ b/.changeset/hungry-ravens-buy.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Updates Pubnub to improve security

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -11,17 +11,24 @@ import {
   Document,
   Sheet,
 } from '@flatfile/react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styles from './page.module.css'
 import { recordHook } from '@flatfile/plugin-record-hook'
 
 const App = () => {
-  const { open, openPortal, closePortal, listener } = useFlatfile()
-
+  const { open, openPortal, closePortal } = useFlatfile()
   const [label, setLabel] = useState('Rock')
   const toggleOpen = () => {
     open ? closePortal({ reset: false }) : openPortal()
   }
+  // useEffect(() => {
+  //   if (!open) setTimeout(openPortal, 1000)
+  // }, [open])
+  
+  useEffect(() => {
+    openPortal()
+  }, [])
+
   useListener((listener) => {
     listener.on('**', (event) => {
       console.log('FFApp useListener Event => ', {

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -21,10 +21,7 @@ const App = () => {
   const toggleOpen = () => {
     open ? closePortal({ reset: false }) : openPortal()
   }
-  // useEffect(() => {
-  //   if (!open) setTimeout(openPortal, 1000)
-  // }, [open])
-  
+
   useEffect(() => {
     openPortal()
   }, [])

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -18,7 +18,7 @@ export const EmbeddedIFrameWrapper = (
     iRef: MutableRefObject<HTMLIFrameElement | null>
   }
 ): JSX.Element => {
-  const { open, sessionSpace } = useContext(FlatfileContext)
+  const { open, sessionSpace, ready } = useContext(FlatfileContext)
 
   const [showExitWarnModal, setShowExitWarnModal] = useState(false)
 
@@ -64,9 +64,10 @@ export const EmbeddedIFrameWrapper = (
 
   const spaceLink = sessionSpace?.space?.guestLink || null
   const openVisible = (open: boolean): React.CSSProperties => ({
-    opacity: open ? 1 : 0,
-    pointerEvents: open ? 'all' : 'none',
+    opacity: ready && open ? 1 : 0,
+    pointerEvents: ready && open ? 'all' : 'none',
   })
+  
   return (
     <div
       className={`flatfile_iframe-wrapper ${
@@ -94,7 +95,7 @@ export const EmbeddedIFrameWrapper = (
           exitSecondaryButtonText={exitSecondaryButtonText}
         />
       )}
-      {(open || preload) && (
+      {((ready && open) || preload) && (
         <iframe
           allow="clipboard-read; clipboard-write"
           className={mountElement}

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -52,6 +52,7 @@ export interface FlatfileContextType {
   setDefaultPage: (object: any) => void
   resetSpace: (options?: ClosePortalOptions) => void
   config?: IFrameTypes
+  ready: boolean
 }
 
 export const FlatfileContext = createContext<FlatfileContextType>({
@@ -78,6 +79,7 @@ export const FlatfileContext = createContext<FlatfileContextType>({
   setDefaultPage: () => {},
   resetSpace: () => {},
   config: undefined,
+  ready: false
 })
 export const useFlatfileInternal = () => useContext(FlatfileContext)
 export default FlatfileContext

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -65,6 +65,14 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     },
     [defaultPage]
   )
+  const [ready, setReady] = useState<boolean>(false);
+
+  useEffect(() => {
+    const isDefaultCreateSpace = JSON.stringify(createSpace) === JSON.stringify(DEFAULT_CREATE_SPACE);
+    if (!isDefaultCreateSpace) {
+      setReady(true);
+    }
+  }, [createSpace]);
 
   const iframe = useRef<HTMLIFrameElement | null>(null)
 
@@ -222,6 +230,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       setDefaultPage,
       resetSpace,
       config: FLATFILE_PROVIDER_CONFIG,
+      ready
     }),
     [
       publishableKey,
@@ -233,6 +242,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       listener,
       createSpace,
       defaultPage,
+      ready,
       FLATFILE_PROVIDER_CONFIG,
     ]
   )

--- a/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
+++ b/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
@@ -26,6 +26,7 @@ export const FlatfileProviderValue: FlatfileContextType = {
   defaultPage: undefined,
   setDefaultPage: jest.fn(),
   resetSpace: jest.fn(),
+  ready: false
 }
 
 fetchMock.enableMocks()

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -1,7 +1,5 @@
-import {
-  updateDefaultPageInSpace
-} from '@flatfile/embedded-utils'
-import { useContext } from 'react'
+import { updateDefaultPageInSpace } from '@flatfile/embedded-utils'
+import { useContext, useEffect } from 'react'
 import FlatfileContext from '../components/FlatfileContext'
 import { ClosePortalOptions } from '../types'
 import { convertDatesToISO } from '../utils/convertDatesToISO'
@@ -34,6 +32,7 @@ export const useFlatfile: () => {
     createSpace,
     defaultPage,
     resetSpace,
+    ready,
   } = context
 
   const handleCreateSpace = async () => {
@@ -75,13 +74,22 @@ export const useFlatfile: () => {
     }
   }
 
+  useEffect(() => {
+    const createOrUpdateSpace = async () => {
+      if (publishableKey && !accessToken) {
+        await handleCreateSpace()
+      } else if (accessToken && !publishableKey) {
+        await handleReUseSpace()
+      }
+    }
+
+    if (ready && open) {
+      createOrUpdateSpace()
+    }
+  }, [ready, open])
+
   const openPortal = () => {
     ;(window as any).CROSSENV_FLATFILE_API_URL = apiUrl
-    if (publishableKey && !accessToken) {
-      handleCreateSpace()
-    } else if (accessToken && !publishableKey) {
-      handleReUseSpace()
-    }
     setOpen(true)
   }
 
@@ -95,5 +103,6 @@ export const useFlatfile: () => {
     open,
     setListener,
     listener,
+    ready,
   }
 }


### PR DESCRIPTION
### Waits for context to be ready to create the Space
This allows for users to open the portal instance on page load:
```ts
useEffect(() => {
    openPortal();
  }, []);
```

#####  Sidenote: Additionally we expose a `ready` variable to the `useFlatfile()` hook that updates to true when the context's `createSpace` is updated from the React Components configuration

