### PR TITLE
fix: Try posting to iFrame if the iframe isn not ready before the context is

### DIFF
--- a/.changeset/dirty-masks-camp.md
+++ b/.changeset/dirty-masks-camp.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fix for some instances where the iframe wasn't ready when the portal:initialize call was posted

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -94,7 +94,7 @@ const App = () => {
           },
         }}
       >
-        <Document defaultPage={true} config={document} />
+        <Document defaultPage config={document} />
         <Workbook
           config={{
             ...workbook,
@@ -119,6 +119,7 @@ const App = () => {
           ]}
         >
           <Sheet
+            defaultPage
             config={{
               ...workbook.sheets![0],
               slug: 'contacts3',
@@ -133,7 +134,6 @@ const App = () => {
             }}
           />
           <Sheet
-            defaultPage={true}
             config={{
               ...workbook.sheets![0],
               slug: 'contacts4',

--- a/apps/react/app/config.ts
+++ b/apps/react/app/config.ts
@@ -30,6 +30,27 @@ export const config: Pick<
           type: 'string',
           label: 'full name',
         },
+        {
+          key: 'status',
+          type: 'enum',
+          label: 'Status',
+          config: {
+            options: [
+              {
+                value: 'blocked',
+                label: 'Blocked',
+              },
+              {
+                value: 'in-progress',
+                label: 'In Progress',
+              },
+              {
+                value: 'completed',
+                label: 'Completed',
+              },
+            ],
+          },
+        },
       ],
       actions: [
         {

--- a/apps/react/next.config.js
+++ b/apps/react/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-    reactStrictMode: false,
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/apps/react/utils/sheet.ts
+++ b/apps/react/utils/sheet.ts
@@ -22,7 +22,30 @@ export const sheet: Flatfile.SheetConfig = {
       label: 'Email',
       config: undefined,
     } as Flatfile.Property.String,
+    {
+      key: 'status',
+      type: 'enum',
+      label: 'Status',
+      config: {
+        allowCustom: true,
+        options: [
+          {
+            value: 'blocked',
+            label: 'Blocked',
+          },
+          {
+            value: 'in-progress',
+            label: 'In Progress',
+          },
+          {
+            value: 'completed',
+            label: 'Completed',
+          },
+        ],
+      },
+    },
   ],
+  allowAdditionalFields: true,
   actions: [
     {
       operation: 'submitActionFg',

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -1,7 +1,8 @@
 import { Flatfile } from '@flatfile/api'
 import FlatfileListener from '@flatfile/listener'
-import { createContext, useContext } from 'react'
+import { RefObject, createContext, createRef, useContext } from 'react'
 import { IFrameTypes, ClosePortalOptions } from '../types'
+import { DefaultPageType } from '@flatfile/embedded-utils'
 
 type CreateNewSpace = Partial<Flatfile.SpaceConfig>
 type ReUseSpace = Partial<Flatfile.SpaceConfig> & {
@@ -48,10 +49,11 @@ export interface FlatfileContextType {
   createSpace: any
   setCreateSpace: (config: any) => void
   updateSpace: (config: any) => void
-  defaultPage: undefined
+  defaultPage: DefaultPageType | undefined
   setDefaultPage: (object: any) => void
   resetSpace: (options?: ClosePortalOptions) => void
   config?: IFrameTypes
+  iframe: RefObject<HTMLIFrameElement>
   ready: boolean
 }
 
@@ -79,7 +81,8 @@ export const FlatfileContext = createContext<FlatfileContextType>({
   setDefaultPage: () => {},
   resetSpace: () => {},
   config: undefined,
-  ready: false
+  ready: false,
+  iframe: createRef<HTMLIFrameElement>()
 })
 export const useFlatfileInternal = () => useContext(FlatfileContext)
 export default FlatfileContext

--- a/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
+++ b/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { createRef, useContext } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { FlatfileProvider } from '../FlatfileProvider'
 import FlatfileContext, {
@@ -26,7 +26,8 @@ export const FlatfileProviderValue: FlatfileContextType = {
   defaultPage: undefined,
   setDefaultPage: jest.fn(),
   resetSpace: jest.fn(),
-  ready: false
+  ready: false,
+  iframe: createRef<HTMLIFrameElement>(),
 }
 
 fetchMock.enableMocks()

--- a/packages/react/src/components/style.scss
+++ b/packages/react/src/components/style.scss
@@ -73,7 +73,8 @@
   display: flex;
   justify-content: flex-end;
 
-  > div {
+  > div,
+  > button {
     align-items: center;
     appearance: button;
     border-radius: 2px;
@@ -90,11 +91,9 @@
     row-gap: 8px;
     tab-size: 4;
     text-align: center;
-    transition-delay: 0s;
-    transition-duration: 0.2s;
-    transition-property: background-color;
-    transition-timing-function: ease;
+    transition: background-color 0.2s ease 0s;
     word-spacing: 0px;
+    border: none;
     -webkit-box-align: center;
     -webkit-box-pack: center;
   }

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -1,10 +1,6 @@
-import { updateDefaultPageInSpace } from '@flatfile/embedded-utils'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import FlatfileContext from '../components/FlatfileContext'
 import { ClosePortalOptions } from '../types'
-import { convertDatesToISO } from '../utils/convertDatesToISO'
-import { createSpaceInternal } from '../utils/createSpaceInternal'
-import { getSpace } from '../utils/getSpace'
 
 export const useFlatfile: () => {
   openPortal: () => void
@@ -19,74 +15,8 @@ export const useFlatfile: () => {
     throw new Error('useFlatfile must be used within a FlatfileProvider')
   }
 
-  const {
-    open,
-    setOpen,
-    setListener,
-    listener,
-    publishableKey,
-    apiUrl,
-    setSessionSpace,
-    accessToken,
-    setAccessToken,
-    createSpace,
-    defaultPage,
-    resetSpace,
-    ready,
-  } = context
-
-  const handleCreateSpace = async () => {
-    if (!publishableKey) {
-      return
-    }
-    // autoConfigure if no workbook or workbook.sheets are provided as they should be handled in the listener space:configure event
-    const autoConfigure = !createSpace.workbook?.sheets
-    const { data: createdSpace } = await createSpaceInternal({
-      apiUrl,
-      publishableKey,
-      space: { ...createSpace.space, autoConfigure },
-      workbook: createSpace.workbook,
-      document: createSpace.document,
-    })
-    // A bit of a hack to wire up the Flatfile API key to the window object for internal client side @flatfile/api usage
-    ;(window as any).CROSSENV_FLATFILE_API_KEY = createdSpace.space.accessToken
-
-    if (defaultPage) await updateDefaultPageInSpace(createdSpace, defaultPage)
-
-    setAccessToken(createdSpace.space.accessToken)
-    setSessionSpace(createdSpace)
-  }
-
-  const handleReUseSpace = async () => {
-    if (accessToken && 'id' in createSpace.space) {
-      createSpace.space.accessToken = accessToken
-      const { data: reUsedSpace } = await getSpace({
-        space: createSpace.space,
-        apiUrl,
-      })
-
-      if (reUsedSpace.accessToken) {
-        ;(window as any).CROSSENV_FLATFILE_API_KEY = reUsedSpace.accessToken
-        setAccessToken(reUsedSpace.accessToken)
-      }
-
-      setSessionSpace({ space: convertDatesToISO(reUsedSpace) })
-    }
-  }
-
-  useEffect(() => {
-    const createOrUpdateSpace = async () => {
-      if (publishableKey && !accessToken) {
-        await handleCreateSpace()
-      } else if (accessToken && !publishableKey) {
-        await handleReUseSpace()
-      }
-    }
-
-    if (ready && open) {
-      createOrUpdateSpace()
-    }
-  }, [ready, open])
+  const { open, setOpen, setListener, listener, apiUrl, resetSpace, ready } =
+    context
 
   const openPortal = () => {
     ;(window as any).CROSSENV_FLATFILE_API_URL = apiUrl

--- a/packages/react/src/utils/useIsIFrameLoaded.ts
+++ b/packages/react/src/utils/useIsIFrameLoaded.ts
@@ -1,0 +1,18 @@
+import type { RefObject } from 'react'
+import { useEffect, useState } from 'react'
+
+export const useIsIFrameLoaded = (
+  iframeRef: RefObject<HTMLIFrameElement>
+): boolean => {
+  const [isIFrameLoaded, setIsIFrameLoaded] = useState<boolean>(false)
+
+  const handler = () => setIsIFrameLoaded(true)
+
+  useEffect(() => {
+    iframeRef.current?.addEventListener('load', handler)
+    return () => {
+      iframeRef.current?.removeEventListener('load', handler)
+    }
+  }, [iframeRef])
+  return isIFrameLoaded
+}


### PR DESCRIPTION
### Fixes 🐛 in the openPortal on load flow
This has been test in `Next.js` and `create-react-app` (which have 2 different behaviors).
For example:
```
  useEffect(() => {
    openPortal()
  }, [])
```