### PR TITLE
Enable cli to infer array of events

### DIFF
--- a/.changeset/spotty-cats-brush.md
+++ b/.changeset/spotty-cats-brush.md
@@ -1,0 +1,5 @@
+---
+'flatfile': patch
+---
+
+Enable event topic inference from arrays

--- a/package-lock.json
+++ b/package-lock.json
@@ -37951,7 +37951,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
-        "@flatfile/api": "^1.8.5",
+        "@flatfile/api": "^1.9.0",
         "@rollup/plugin-babel": "^6.0.3",
         "@types/inquirer": "^9.0.2",
         "@types/prompts": "^2.4.4",
@@ -37962,6 +37962,28 @@
         "chalk": "^4.1.2",
         "inquirer": "^9.1.3"
       }
+    },
+    "packages/cli/node_modules/@flatfile/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-WL9ATkzZ47qr/Po32B+rH3cEkdPardjmnDlDP7WGfpeiuNbqj4dFljCXhInefcMUsh5OR9p2nlXeTfzoysleGQ==",
+      "dev": true,
+      "dependencies": {
+        "@flatfile/cross-env-config": "0.0.4",
+        "@types/pako": "2.0.1",
+        "form-data": "4.0.0",
+        "js-base64": "3.7.2",
+        "node-fetch": "2.7.0",
+        "pako": "2.0.1",
+        "qs": "6.11.2",
+        "url-join": "4.0.1"
+      }
+    },
+    "packages/cli/node_modules/@flatfile/api/node_modules/@flatfile/cross-env-config": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@flatfile/cross-env-config/-/cross-env-config-0.0.4.tgz",
+      "integrity": "sha512-mNaqtASTly4N09pjQts5zDnYXFLC891TCxJEiFUnil8p6lQciyd0gnPSnhJD0TTlO5817gX3mLE9RDoAETtIbg==",
+      "dev": true
     },
     "packages/cli/node_modules/@rollup/plugin-json": {
       "version": "5.0.2",
@@ -38005,6 +38027,50 @@
         "tslib": {
           "optional": true
         }
+      }
+    },
+    "packages/cli/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "packages/cli/node_modules/pako": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.1.tgz",
+      "integrity": "sha512-mqHoEQRZ4d+JREr7Csg+QbdfuOHtojEmsAKo/cYiCJICjjB0mOMSKnRlL42P5luMWUXksJ7UDZCRkEqPrBj0Dg==",
+      "dev": true
+    },
+    "packages/cli/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "packages/cli/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "packages/cli/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/configure": {
@@ -42899,7 +42965,7 @@
     },
     "packages/react": {
       "name": "@flatfile/react",
-      "version": "7.9.8",
+      "version": "7.9.9",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.8.5",
@@ -45168,7 +45234,7 @@
     },
     "packages/vue": {
       "name": "@flatfile/vue",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "dependencies": {
         "@flatfile/embedded-utils": "1.2.4",
         "@flatfile/listener": "^1.0.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
-    "@flatfile/api": "^1.8.5",
+    "@flatfile/api": "^1.9.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@types/inquirer": "^9.0.2",
     "@types/prompts": "^2.4.4",

--- a/packages/cli/src/x/actions/deploy.action.ts
+++ b/packages/cli/src/x/actions/deploy.action.ts
@@ -74,18 +74,20 @@ async function handleAgentSelection(
 }
 
 function findActiveTopics(allTopics: ListenerTopics[], client: any, topicsWithListeners = new Set()) {
-  client.listeners?.forEach((listener: ListenerTopics[]) => {
-    const listenerTopic = listener[0]
-    if (listenerTopic === '**') {
-      // Filter cron events out of '**' list - they must be added explicitly
-      const filteredTopics = allTopics.filter(event => !event.startsWith('cron:'))
-      filteredTopics.forEach(topic => topicsWithListeners.add(topic))
-    } else if (listenerTopic.includes('**')) {
-      const [prefix] = listenerTopic.split(':')
-      allTopics.forEach(topic => { if (topic.split(':')[0] === prefix) topicsWithListeners.add(topic) })
-    } else if (allTopics.includes(listenerTopic)) {
-      topicsWithListeners.add(listenerTopic)
-    }
+  client.listeners?.forEach((listener: ListenerTopics | ListenerTopics[]) => {
+    const listenerTopics = Array.isArray(listener[0]) ? listener[0] : [listener[0]]
+    listenerTopics.forEach(listenerTopic => {
+      if (listenerTopic === '**') {
+        // Filter cron events out of '**' list - they must be added explicitly
+        const filteredTopics = allTopics.filter(event => !event.startsWith('cron:'))
+        filteredTopics.forEach(topic => topicsWithListeners.add(topic))
+      } else if (listenerTopic.includes('**')) {
+        const [prefix] = listenerTopic.split(':')
+        allTopics.forEach(topic => { if (topic.split(':')[0] === prefix) topicsWithListeners.add(topic) })
+      } else if (allTopics.includes(listenerTopic)) {
+        topicsWithListeners.add(listenerTopic)
+      }
+    })
   })
   client.nodes?.forEach((nestedClient: any) => findActiveTopics(allTopics, nestedClient, topicsWithListeners))
   return topicsWithListeners


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This fixes an issue with the cli was not picking up all the events in an array if an array of topics was passed to the listener.

Also updates the @flatfile/api package.

## Tell code reviewer how and what to test:

Check when both the listener topics are arrays and when its a string.

eg string:
```
export default (listener) => {
  listener.on('commit:created', (event) => console.log(event))
}
```

eg array:
```
export default (listener) => {
  listener.on(['commit:created', 'layer:created'], (event) => console.log(event))
}
```

Closes https://github.com/FlatFilers/flatfile-core-libraries/issues/127