### PR TITLE
clean up close event handling

### DIFF
--- a/.changeset/honest-donkeys-cry.md
+++ b/.changeset/honest-donkeys-cry.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/embedded-utils': minor
+'@flatfile/javascript': patch
+---
+
+Use updated embedded-utils to avoid registering two 'message' event handlers

--- a/packages/embedded-utils/src/utils/handlePostMessage.ts
+++ b/packages/embedded-utils/src/utils/handlePostMessage.ts
@@ -3,11 +3,14 @@ import { ISpace } from '../types'
 
 export const handlePostMessage = (
   closeSpace: ISpace['closeSpace'],
-  listener: FlatfileListener
+  listener: FlatfileListener,
+  onClose?: () => void
 ) => {
   return (message: MessageEvent<{ flatfileEvent: FlatfileEvent }>) => {
     const { flatfileEvent } = message.data
-    if (!flatfileEvent) return
+    if (!flatfileEvent) {
+      return
+    }
     if (
       flatfileEvent.topic === 'job:outcome-acknowledged' &&
       flatfileEvent.payload.status === 'complete' &&
@@ -15,7 +18,8 @@ export const handlePostMessage = (
       closeSpace &&
       typeof closeSpace.onClose === 'function'
     ) {
-      closeSpace.onClose({event: flatfileEvent})
+      closeSpace.onClose({ event: flatfileEvent })
+      onClose?.()
     }
     listener.dispatchEvent(flatfileEvent)
   }

--- a/packages/javascript/FlatfileJavascript.ts
+++ b/packages/javascript/FlatfileJavascript.ts
@@ -127,8 +127,8 @@ const createSimpleListener = ({
  * @param exitText
  * @param exitPrimaryButtonText
  * @param exitSecondaryButtonText
+ * @param closeSpaceNow
  * @param closeSpace
- * @param removeMessageListener
  * @param onCancel
  */
 function initializeIFrameConfirmationModal(

--- a/packages/javascript/FlatfileJavascript.ts
+++ b/packages/javascript/FlatfileJavascript.ts
@@ -34,6 +34,16 @@ const displayError = (errorTitle: string, errorMessage: string) => {
   return display
 }
 
+/**
+ * Add a listener to handle postMessage events
+ *
+ * @param accessToken
+ * @param apiUrl
+ * @param listener
+ * @param closeSpace
+ * @param onClose
+ * @returns Promise<() => void>
+ */
 async function createlistener(
   accessToken: string,
   apiUrl: string,

--- a/packages/javascript/FlatfileJavascript.ts
+++ b/packages/javascript/FlatfileJavascript.ts
@@ -38,14 +38,15 @@ async function createlistener(
   accessToken: string,
   apiUrl: string,
   listener: FlatfileListener,
-  closeSpace: NewSpaceFromPublishableKey['closeSpace']
+  closeSpace: NewSpaceFromPublishableKey['closeSpace'],
+  onClose: () => void
 ): Promise<() => void> {
   const browser_instance = new Browser({
     apiUrl,
     accessToken,
     fetchApi: fetch,
   })
-  const ff_message_handler = handlePostMessage(closeSpace, listener)
+  const ff_message_handler = handlePostMessage(closeSpace, listener, onClose)
 
   listener.mount(browser_instance)
   window.addEventListener('message', ff_message_handler, false)
@@ -137,8 +138,8 @@ function initializeIFrameConfirmationModal(
   exitText: string,
   exitPrimaryButtonText: string,
   exitSecondaryButtonText: string,
+  closeSpaceNow: () => void,
   closeSpace?: ISpace['closeSpace'],
-  removeMessageListener?: () => void,
   onCancel?: () => void
 ) {
   // Create the confirmation modal and hide it
@@ -175,35 +176,6 @@ function initializeIFrameConfirmationModal(
   )
   confirmModal.style.display = 'none'
   document.body.appendChild(confirmModal)
-
-  function closeFlatfileSpace(event: any) {
-    if (event?.data?.flatfileEvent) {
-      const { flatfileEvent } = event.data
-      if (
-        flatfileEvent.topic === 'job:outcome-acknowledged' &&
-        flatfileEvent.payload.status === 'complete' &&
-        flatfileEvent.payload.operation === closeSpace?.operation
-      ) {
-        closeSpaceNow()
-      }
-    }
-  }
-
-  function closeSpaceNow() {
-    if (removeMessageListener) {
-      removeMessageListener()
-    }
-    window.removeEventListener('message', closeFlatfileSpace, false)
-    const outerShell = document.querySelector(
-      '.flatfile_outer-shell'
-    ) as HTMLElement
-    if (outerShell) {
-      outerShell.remove()
-    }
-    domElement.remove()
-  }
-
-  window.addEventListener('message', closeFlatfileSpace, false)
 
   if (displayAsModal) {
     const closeButton = document.createElement('div')
@@ -461,17 +433,24 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
     }
     // Set these for handy use in the listeners for authenticating the @flatfile/api client
 
-    let removeMessageListener: () => void | undefined
+    let removeMessageListener: (() => void) | undefined
 
     const simpleListenerSlug: string =
       createdWorkbook?.sheets?.[0].slug || 'slug'
+
+    function closeSpaceNow() {
+      removeMessageListener?.()
+      document.querySelector('.flatfile_outer-shell')?.remove?.()
+      mountIFrameWrapper?.remove?.()
+    }
 
     if (listener) {
       removeMessageListener = await createlistener(
         spaceResult.accessToken,
         apiUrl,
         listener,
-        closeSpace
+        closeSpace,
+        closeSpaceNow
       )
     } else {
       removeMessageListener = await createlistener(
@@ -482,7 +461,8 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
           onSubmit: simpleOnboardingOptions?.onSubmit,
           slug: simpleListenerSlug,
         }),
-        closeSpace
+        closeSpace,
+        closeSpaceNow
       )
     }
 
@@ -531,8 +511,8 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
         exitText,
         exitPrimaryButtonText,
         exitSecondaryButtonText,
+        closeSpaceNow,
         closeSpace,
-        removeMessageListener,
         simpleOnboardingOptions?.onCancel
       )
     }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Consolidates close event handling into a single `addEventListener` call

## Tell code reviewer how and what to test:

Test `apps/vanilla` both preloaded and on-demand, and ensure that the close event is logged in the console after submitting and acknowledging submit success by pressing "Continue"
