### PR TITLE
feat: Fix `defaultPage` in Vue

### DIFF
--- a/.changeset/bright-sloths-rule.md
+++ b/.changeset/bright-sloths-rule.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/vue': patch
+---
+
+Add setting DefaultPage to Document, Workbook and Sheet

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -1,48 +1,55 @@
-
 <script lang="jsx">
-import { ref, onMounted, h, defineComponent } from 'vue';
-import { initializeFlatfile } from '@flatfile/vue';
-import { workbook } from "./config";
+import { ref, onMounted, h, defineComponent } from 'vue'
+import { initializeFlatfile } from '@flatfile/vue'
+import { workbook } from './config'
 import { listener } from './listener'
 
-const SPACE_ID = 'us_sp_12314';
-const ENVIRONMENT_ID = 'us_env_1234';
+const SPACE_ID = 'us_sp_12314'
+const ENVIRONMENT_ID = 'us_env_1234'
 
 export default defineComponent({
   setup() {
-    const publishableKey = 'your_key';
-    const environmentId = ENVIRONMENT_ID;
+    const publishableKey = 'pk_ixtxE3L9iVMYgaaxePSn5hGxLffNJhiS'
     const spaceProps = ref({
       name: 'Trste!',
-      environmentId,
       publishableKey,
       workbook,
       listener,
-      themeConfig: { primaryColor: "#546a76", textColor: "#fff" },
+      document: {
+        title: 'Instructions',
+        body:
+          '# Supported file types\n' +
+          '---\n' +
+          'Please only import CSV and Excel files',
+        defaultPage: true,
+      },
+
+      themeConfig: { primaryColor: '#546a76', textColor: '#fff' },
       userInfo: {
-        name: 'my space name'
+        name: 'my space name',
       },
       spaceInfo: {
-        name: 'my space name'
+        name: 'my space name',
       },
       displayAsModal: true,
       spaceBody: {
         metadata: {
-          random: 'param'
-        }
-      }
-    });
+          sidebarConfig: {
+            showSidebar: true,
+          },
+        },
+      },
+    })
 
-
-    const { Space, OpenEmbed } = initializeFlatfile(spaceProps.value);
+    const { Space, OpenEmbed } = initializeFlatfile(spaceProps.value)
 
     const toggleSpace = () => {
       OpenEmbed()
-    };
+    }
 
     return {
       toggleSpace,
-      Space
+      Space,
     }
   },
   render(props, ctx) {
@@ -58,5 +65,5 @@ export default defineComponent({
       </div>
     )
   },
-});
+})
 </script>

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -4,13 +4,11 @@ import { initializeFlatfile } from '@flatfile/vue'
 import { workbook } from './config'
 import { listener } from './listener'
 
-const SPACE_ID = 'us_sp_12314'
-const ENVIRONMENT_ID = 'us_env_1234'
-
 export default defineComponent({
   setup() {
     const publishableKey = 'your_key'
     const spaceProps = ref({
+      // apiUrl: 'https://platform.flatfile.com/api',
       name: 'Trste!',
       publishableKey,
       workbook,
@@ -32,12 +30,9 @@ export default defineComponent({
         name: 'my space name',
       },
       displayAsModal: true,
-      spaceBody: {
-        metadata: {
-          sidebarConfig: {
-            showSidebar: true,
-          },
-        },
+      spaceBody: {},
+      sidebarConfig: {
+        showSidebar: true,
       },
     })
 

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -9,7 +9,7 @@ const ENVIRONMENT_ID = 'us_env_1234'
 
 export default defineComponent({
   setup() {
-    const publishableKey = 'pk_ixtxE3L9iVMYgaaxePSn5hGxLffNJhiS'
+    const publishableKey = 'your_key'
     const spaceProps = ref({
       name: 'Trste!',
       publishableKey,

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -12,7 +12,7 @@ export default defineComponent({
     const publishableKey = 'your_key'
     const spaceProps = ref({
       name: 'Trste!',
-      publishableKey,
+      publishableKey: "",
       workbook,
       listener,
       document: {

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -4,9 +4,11 @@ import { initializeFlatfile } from '@flatfile/vue'
 import { workbook } from './config'
 import { listener } from './listener'
 
+const FLATFILE_PUBLISHABLE_KEY = 'your_key'
+
 export default defineComponent({
   setup() {
-    const publishableKey = 'your_key'
+    const publishableKey = FLATFILE_PUBLISHABLE_KEY
     const spaceProps = ref({
       // apiUrl: 'https://platform.flatfile.com/api',
       name: 'Trste!',

--- a/apps/vue/src/App.vue
+++ b/apps/vue/src/App.vue
@@ -12,7 +12,7 @@ export default defineComponent({
     const publishableKey = 'your_key'
     const spaceProps = ref({
       name: 'Trste!',
-      publishableKey: "",
+      publishableKey,
       workbook,
       listener,
       document: {

--- a/apps/vue/src/config.ts
+++ b/apps/vue/src/config.ts
@@ -1,9 +1,4 @@
-import { Flatfile } from '@flatfile/api'
-
-export const workbook: Pick<
-  Flatfile.CreateWorkbookConfig,
-  'name' | 'labels' | 'sheets' | 'actions'
-> = {
+export const workbook = {
   name: 'All Data',
   labels: ['pinned'],
   sheets: [
@@ -11,6 +6,29 @@ export const workbook: Pick<
       name: 'Contacts',
       slug: 'contacts',
       allowAdditionalFields: true,
+      fields: [
+        {
+          key: 'firstName',
+          type: 'string',
+          label: 'First Name',
+        },
+        {
+          key: 'lastName',
+          type: 'string',
+          label: 'Last Name',
+        },
+        {
+          key: 'email',
+          type: 'string',
+          label: 'Email',
+        },
+      ],
+    },
+    {
+      name: 'Contacts 2',
+      slug: 'contacts2',
+      allowAdditionalFields: true,
+      defaultPage: true,
       fields: [
         {
           key: 'firstName',

--- a/apps/vue/src/config.ts
+++ b/apps/vue/src/config.ts
@@ -28,7 +28,7 @@ export const workbook = {
       name: 'Contacts 2',
       slug: 'contacts2',
       allowAdditionalFields: true,
-      defaultPage: true,
+      // defaultPage: true,
       fields: [
         {
           key: 'firstName',

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -83,6 +83,9 @@ const baseConfig = {
       extensions: ['.js', '.jsx', '.vue'],
       babelHelpers: 'bundled',
     },
+    replace: {
+      preventAssignment: true
+    }
   },
 }
 

--- a/packages/vue/src/components/initializeFlatfile.ts
+++ b/packages/vue/src/components/initializeFlatfile.ts
@@ -23,7 +23,7 @@ export const initializeFlatfile = (props: ISpace) => {
     loading: LoadingElement,
     apiUrl = 'https://platform.flatfile.com/api',
   } = props
-  console.log('initializeFlatfile', { props })
+
   const initError = ref<Error | null>(null)
   const closeInstance = ref<boolean>(false)
   const loading = ref<boolean>(false)

--- a/packages/vue/src/components/initializeFlatfile.ts
+++ b/packages/vue/src/components/initializeFlatfile.ts
@@ -23,7 +23,7 @@ export const initializeFlatfile = (props: ISpace) => {
     loading: LoadingElement,
     apiUrl = 'https://platform.flatfile.com/api',
   } = props
-
+  console.log('initializeFlatfile', { props })
   const initError = ref<Error | null>(null)
   const closeInstance = ref<boolean>(false)
   const loading = ref<boolean>(false)

--- a/packages/vue/src/utils/addSpaceInfo.ts
+++ b/packages/vue/src/utils/addSpaceInfo.ts
@@ -1,4 +1,4 @@
-import { Flatfile, FlatfileClient } from '@flatfile/api'
+import { FlatfileClient } from '@flatfile/api'
 import {
   NewSpaceFromPublishableKey,
   getErrorMessage,

--- a/packages/vue/src/utils/addSpaceInfo.ts
+++ b/packages/vue/src/utils/addSpaceInfo.ts
@@ -20,7 +20,11 @@ const addSpaceInfo = async (
   } = spaceProps
   let defaultPage
   let defaultPageSet = false
-  const setDefaultPage = (incomingDefaultPage: any) => {
+  const setDefaultPage = (
+    incomingDefaultPage:
+      | { workbook: { workbookId: string; sheetId?: string } }
+      | { documentId: string }
+  ) => {
     if (defaultPageSet === true) {
       console.warn(
         'Default page is already set. Multiple default pages are not allowed.'
@@ -39,8 +43,6 @@ const addSpaceInfo = async (
         ...workbook,
       })
 
-      console.log({ localWorkbook })
-
       if (workbook.defaultPage) {
         setDefaultPage({
           workbook: {
@@ -49,8 +51,19 @@ const addSpaceInfo = async (
         })
       } else if (workbook.sheets) {
         const defaultSheet = workbook.sheets.find((sheet) => sheet.defaultPage)
-        if (defaultSheet && defaultSheet.slug) {
-          setDefaultPage({ workbook: { sheet: defaultSheet.slug } })
+        if (!defaultSheet || !defaultSheet.slug) {
+          throw new Error('Default sheet not found')
+        }
+        const foundSheet = localWorkbook.data.sheets?.find(
+          (sheet) => sheet.slug === defaultSheet.slug
+        )
+        if (defaultSheet && defaultSheet.slug && foundSheet) {
+          setDefaultPage({
+            workbook: {
+              workbookId: localWorkbook.data.id,
+              sheetId: foundSheet.id,
+            },
+          })
         }
       }
 

--- a/packages/vue/src/utils/initializeSpace.ts
+++ b/packages/vue/src/utils/initializeSpace.ts
@@ -24,7 +24,6 @@ export const initializeSpace = async (
     sheet,
     onSubmit,
   } = flatfileOptions
-
   try {
     if (!publishableKey) {
       throw new Error('Missing required publishable key')


### PR DESCRIPTION
Allows setting the defaultPage on a `Document`, `Workbook` or `Sheet` when creating a New Space in the Portal.

An example of setting the `defaultPage` on a Document:
```
const spaceProps = ref({
  name: 'Trste!',
  publishableKey,
  workbook,
  listener,
  document: {
    title: 'Instructions',
    body:
      '# Supported file types\n' +
      '---\n' +
      'Please only import CSV and Excel files',
    defaultPage: true,
  },
})
```

An example of setting the `defaultPage` on a Sheet in a Workbook:
```
export const workbook = {
  name: 'All Data',
  labels: ['pinned'],
  sheets: [
    {
      name: 'Contacts',
      slug: 'contacts',
      allowAdditionalFields: true,
      fields: [...],
    },
    {
      name: 'Contacts 2',
      slug: 'contacts2',
      allowAdditionalFields: true,
      defaultPage: [...],
    },
  ]
}

```

