### PR TITLE
fix(react): prevent closed Flatfile modal from covering page

### DIFF
--- a/.changeset/young-ants-whisper.md
+++ b/.changeset/young-ants-whisper.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Prevents Flatfile modal from blocking scroll on some browsers when closed.

--- a/apps/react/app/page.module.css
+++ b/apps/react/app/page.module.css
@@ -1,4 +1,5 @@
 .main {
+  box-sizing: border-box;
   padding: 30px;
   min-height: 100vh;
 }

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -1,4 +1,11 @@
-import React, { JSX, useContext, useEffect, useState } from 'react'
+import React, {
+  JSX,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { IFrameTypes } from '../types'
 import { useIsIFrameLoaded } from '../utils/useIsIFrameLoaded'
 import { CloseButton } from './CloseButton'
@@ -16,14 +23,14 @@ export const EmbeddedIFrameWrapper = (
   const [showExitWarnModal, setShowExitWarnModal] = useState(false)
   const {
     closeSpace,
-    iframeStyles,
-    mountElement = 'flatfile_iFrameContainer',
-    exitText = 'Are you sure you want to exit? Any unsaved changes will be lost.',
-    exitTitle = 'Close Window',
+    displayAsModal = true,
     exitPrimaryButtonText = 'Yes, exit',
     exitSecondaryButtonText = 'No, stay',
-    displayAsModal = true,
+    exitText = 'Are you sure you want to exit? Any unsaved changes will be lost.',
+    exitTitle = 'Close Window',
     handleCloseInstance,
+    iframeStyles,
+    mountElement = 'flatfile_iFrameContainer',
     preload = true,
     spaceUrl,
   } = props
@@ -58,19 +65,31 @@ export const EmbeddedIFrameWrapper = (
   const openVisible = (open: boolean): React.CSSProperties => ({
     opacity: ready && open ? 1 : 0,
     pointerEvents: ready && open ? 'all' : 'none',
+    visibility: open ? 'visible' : 'hidden',
+    left: ready && open ? '0' : '-200vw',
+    top: ready && open ? '0' : '-200vh',
   })
-
   const iframeSrc = preload ? preloadUrl : spaceLink
+  const modalRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    if (modalRef.current) {
+      const containerStyles = getContainerStyles(displayAsModal)
+      Object.assign(modalRef.current.style, {
+        ...containerStyles,
+        ...openVisible(open),
+        width: ready && open ? containerStyles.width : '0',
+        height: ready && open ? containerStyles.height : '0',
+      })
+    }
+  }, [open, ready, modalRef.current])
 
   return (
     <div
       className={`flatfile_iframe-wrapper ${
         displayAsModal ? 'flatfile_displayAsModal' : ''
       }`}
-      style={{
-        ...getContainerStyles(displayAsModal),
-        ...openVisible(open),
-      }}
+      ref={modalRef}
       data-testid="space-contents"
     >
       {showExitWarnModal && (

--- a/packages/react/src/components/embeddedStyles.tsx
+++ b/packages/react/src/components/embeddedStyles.tsx
@@ -16,15 +16,13 @@ export const getIframeStyles = (styles: React.CSSProperties) => {
 export const getContainerStyles = (isModal: boolean): React.CSSProperties => {
   if (isModal) {
     return {
-      width: 'calc(100% - 100px)',
-      height: 'calc(100vh - 40px)',
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      zIndex: 1000,
       backgroundColor: 'rgba(0, 0, 0, 0.1)',
       display: 'flex',
+      height: 'calc(100vh - 40px)',
+      width: 'calc(100% - 100px)',
       padding: '50px',
+      position: 'fixed',
+      zIndex: '1000',
     }
   } else {
     return {

--- a/packages/react/src/components/embeddedStyles.tsx
+++ b/packages/react/src/components/embeddedStyles.tsx
@@ -14,23 +14,21 @@ export const getIframeStyles = (styles: React.CSSProperties) => {
 }
 
 export const getContainerStyles = (isModal: boolean): React.CSSProperties => {
-  if (isModal) {
-    return {
-      backgroundColor: 'rgba(0, 0, 0, 0.1)',
-      display: 'flex',
-      height: 'calc(100vh - 40px)',
-      width: 'calc(100% - 100px)',
-      padding: '50px',
-      position: 'fixed',
-      zIndex: '1000',
-    }
-  } else {
-    return {
-      width: '100%',
-      height: '100%',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-    }
-  }
+  return isModal
+    ? {
+        backgroundColor: 'rgba(0, 0, 0, 0.1)',
+        display: 'flex',
+        height: 'calc(100vh - 40px)',
+        width: 'calc(100% - 100px)',
+        padding: '50px',
+        position: 'fixed',
+        zIndex: '1000',
+      }
+    : {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }
 }

--- a/packages/react/src/components/style.scss
+++ b/packages/react/src/components/style.scss
@@ -45,7 +45,7 @@
   font-size: var(--size-base);
   line-height: 1.5;
   margin: 0;
-  transition: 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
 }
 
 .flatfile-close-button {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Prevents Flatfile modal from blocking scroll on some browsers when closed

## Tell code reviewer how and what to test:

In `apps/react`, test that the closed modal no longer covers the entire page, can use inspect element to confirm. Does not affect smooth opening fade in transition.

When open:

![Screenshot from 2024-07-01 11-06-53](https://github.com/FlatFilers/flatfile-core-libraries/assets/688553/146b8f0c-0f32-4725-a9dc-01de2447f143)

When closed:

![Screenshot from 2024-07-01 11-07-02](https://github.com/FlatFilers/flatfile-core-libraries/assets/688553/79b2100b-df25-4398-986a-d3a564223dcd)

Fixes https://github.com/FlatFilers/support-triage/issues/1417



