### PR TITLE
feat(react): attachStyleSheet must be done manually now

### DIFF
--- a/.changeset/thirty-boxes-approve.md
+++ b/.changeset/thirty-boxes-approve.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': major
+---
+
+Now required to attach stylesheet explicitly with attachStyleSheet() from @flatfile/react

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -1,19 +1,22 @@
 'use client'
-import { workbook } from '@/utils/workbook'
 import { document } from '@/utils/document'
+import { workbook } from '@/utils/workbook'
+import { recordHook } from '@flatfile/plugin-record-hook'
 import {
+  attachStyleSheet,
+  Document,
+  Sheet,
+  Space,
+  useEvent,
   useFlatfile,
   useListener,
   usePlugin,
-  useEvent,
   Workbook,
-  Space,
-  Document,
-  Sheet,
 } from '@flatfile/react'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import styles from './page.module.css'
-import { recordHook } from '@flatfile/plugin-record-hook'
+
+attachStyleSheet({ nonce: 'flatfile-abc123' }) // add custom nonce
 
 const App = () => {
   const { open, openPortal, closePortal } = useFlatfile()

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -47,7 +47,10 @@ function commonPlugins(browser, umd = false) {
       fileName: '[dirname][name][extname]',
     }),
     PROD ? terser() : null,
-    postcss(),
+    postcss({
+      extract: false,
+      inject: false,
+    }),
   ]
 }
 

--- a/packages/react/src/components/ConfirmCloseModal.tsx
+++ b/packages/react/src/components/ConfirmCloseModal.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-// TODO: make this style import configurable
-import './style.scss'
 
 export const ConfirmCloseModal = ({
   onConfirm,

--- a/packages/react/src/components/Spinner.tsx
+++ b/packages/react/src/components/Spinner.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
-import './style.scss'
 
 const Spinner = () => {
-  return <div
-    className="spinner"
-    data-testid="spinner-icon"
-  />
+  return <div className="spinner" data-testid="spinner-icon" />
 }
 
 export default Spinner

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,8 +5,18 @@ import type {
   IThemeConfig,
   IUserInfo,
 } from '@flatfile/embedded-utils'
+
+import stylesheet from './components/style.scss'
+import { styleInject } from './utils/styleInject'
 export { makeTheme } from './utils/makeTheme'
 
-export * from './hooks'
 export * from './components'
+export * from './hooks'
 export type { ISidebarConfig, ISpace, ISpaceInfo, IThemeConfig, IUserInfo }
+
+export function attachStyleSheet(options?: {
+  insertAt?: 'top'
+  nonce?: string
+}) {
+  styleInject(stylesheet, options)
+}

--- a/packages/react/src/scss.d.ts
+++ b/packages/react/src/scss.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: string
+  export default content
+}

--- a/packages/react/src/utils/styleInject.ts
+++ b/packages/react/src/utils/styleInject.ts
@@ -1,0 +1,30 @@
+// adapted from https://github.com/egoist/style-inject
+
+export function styleInject(
+  css: string,
+  { insertAt, nonce }: { insertAt?: 'top'; nonce?: string } = {}
+) {
+  if (!css || typeof document === 'undefined') return
+
+  const head = document.head || document.getElementsByTagName('head')[0]
+  const style = document.createElement('style')
+  style.type = 'text/css'
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild)
+    } else {
+      head.appendChild(style)
+    }
+  } else {
+    head.appendChild(style)
+  }
+  if (nonce) {
+    style.setAttribute('nonce', nonce)
+  }
+  if ((style as any).styleSheet) {
+    ;(style as any).styleSheet.cssText = css
+  } else {
+    style.appendChild(document.createTextNode(css))
+  }
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,22 +1,13 @@
 {
-    "extends": "@flatfile/ts-config-platform-sdk/base.json",
-    "include": [
-        "./src",
-        "src/index.ts"
-    ],
-    "exclude": [
-        "dist",
-        "build",
-        "node_modules"
-    ],
-    "compilerOptions": {
-        "lib": [
-            "ESNext",
-            "DOM"
-        ],
-        "module": "ESNext",
-        "target": "ES6",
-        "jsx": "react",
-        "noEmit": true
-    },
+  "extends": "@flatfile/ts-config-platform-sdk/base.json",
+  "include": ["./src", "src/index.ts"],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "module": "ESNext",
+    "target": "ES6",
+    "jsx": "react",
+    "noEmit": true,
+    "types": ["./src/scss.d.ts"]
+  }
 }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Now required to attach stylesheet explicitly with attachStyleSheet() from @flatfile/react, with optional nonce property to support Content Security Policies that apply to style tags.

## Tell code reviewer how and what to test:

In `apps/react`, verify that the attached Flatfile stylesheet has the expected `nonce` attribute:

![Screenshot from 2024-07-03 10-59-27](https://github.com/FlatFilers/flatfile-core-libraries/assets/688553/b5aec355-45c0-4fe8-83c2-9834c0291b97)

Resolves https://github.com/FlatFilers/support-triage/issues/1021
