### PR TITLE
feat(javascript): add i18n to wrapper

### DIFF
--- a/packages/embedded-utils/src/utils/handlePostMessage.ts
+++ b/packages/embedded-utils/src/utils/handlePostMessage.ts
@@ -8,14 +8,19 @@ export const handlePostMessage = (
   onInit?: (data: { localTranslations: Record<string, any> }) => void
 ) => {
   return (message: MessageEvent<{ flatfileEvent: FlatfileEvent }>) => {
+    if (message.data && 'localTranslations' in message.data) {
+      const localTranslations = message.data.localTranslations as Record<
+        string,
+        any
+      >
+      onInit?.({ localTranslations })
+      return
+    }
     const { flatfileEvent } = message.data
     if (!flatfileEvent) {
       return
     }
-    if (flatfileEvent.topic === 'space:opened') {
-      const { localTranslations } = flatfileEvent.payload
-      onInit?.({ localTranslations })
-    } else if (
+    if (
       flatfileEvent.topic === 'job:outcome-acknowledged' &&
       flatfileEvent.payload.status === 'complete' &&
       flatfileEvent.payload.operation === closeSpace?.operation &&

--- a/packages/embedded-utils/src/utils/handlePostMessage.ts
+++ b/packages/embedded-utils/src/utils/handlePostMessage.ts
@@ -21,10 +21,10 @@ export const handlePostMessage = (
       return
     }
     if (
+      closeSpace &&
       flatfileEvent.topic === 'job:outcome-acknowledged' &&
       flatfileEvent.payload.status === 'complete' &&
-      flatfileEvent.payload.operation === closeSpace?.operation &&
-      closeSpace &&
+      flatfileEvent.payload.operation === closeSpace.operation &&
       typeof closeSpace.onClose === 'function'
     ) {
       closeSpace.onClose({ event: flatfileEvent })


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Last PR's changelog covers this #142 

## Tell code reviewer how and what to test:

Requires https://github.com/FlatFilers/Platform/pull/7809

For now keys are only set in Chinese (zh). This can be tested by choosing the override language in the dropdown:

![Screenshot from 2024-07-15 18-31-41](https://github.com/user-attachments/assets/18604a41-6968-40ec-835b-369513c18d97)

If you wait long enough before clicking close, so that the postMessage containing translation data may be received by `@flatfile/javascript`:

![Screenshot from 2024-07-15 18-49-55](https://github.com/user-attachments/assets/92ded633-632a-4b32-b03d-9b5e9e737365)

If you close the modal right away before it finished loading, you get the default fallback english strings (or custom overrides provided, which override any translation files):

![Screenshot from 2024-07-15 18-50-11](https://github.com/user-attachments/assets/c441771f-84db-4a70-a80b-41db9fdb55dd)
