### PR TITLE
fix(actions): use GH_TOKEN instead of GITHUB_TOKEN for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN  }}


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Uses GH_TOKEN to overcome the inherent limitations of [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

## Tell code reviewer how and what to test:

Attempt a release

