### PR TITLE
fix: Re-Attach Listener After AccessToken Updates

### DIFF
--- a/.changeset/fast-peaches-return.md
+++ b/.changeset/fast-peaches-return.md
@@ -2,4 +2,4 @@
 '@flatfile/react': patch
 ---
 
-Fix for addign and changing listeners when not inline
+Fix for adding and changing listeners when not inline

--- a/.changeset/fast-peaches-return.md
+++ b/.changeset/fast-peaches-return.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fix for addign and changing listeners when not inline

--- a/packages/react/src/hooks/useEvent.ts
+++ b/packages/react/src/hooks/useEvent.ts
@@ -24,7 +24,7 @@ function useEvent(
     | any[] = [],
   dependencies: any[] = []
 ) {
-  const { listener } = useContext(FlatfileContext)
+  const { listener, accessToken } = useContext(FlatfileContext)
 
   let callback: (event: any) => void | Promise<void>
   let actualDependencies: any[] = dependencies
@@ -38,7 +38,7 @@ function useEvent(
   }
 
   useEffect(() => {
-    if (!listener || !callback) return
+    if (!listener || !callback || callback.toString() === '() => {}') return
     // Conditionally apply the filter
     if (typeof filterOrCallback !== 'function') {
       listener.on(eventType, filterOrCallback, callback)
@@ -53,7 +53,14 @@ function useEvent(
         listener.off(eventType, callback)
       }
     }
-  }, [listener, eventType, filterOrCallback, callback, ...actualDependencies])
+  }, [
+    listener,
+    accessToken,
+    eventType,
+    filterOrCallback,
+    callback,
+    ...actualDependencies,
+  ])
 }
 
 export { useEvent }

--- a/packages/react/src/hooks/useListener.ts
+++ b/packages/react/src/hooks/useListener.ts
@@ -6,7 +6,7 @@ export function useListener(
   cb: FlatfileListener | ((cb: FlatfileListener) => void),
   dependencies: any[] = []
 ) {
-  const { listener } = useContext(FlatfileContext)
+  const { listener, accessToken } = useContext(FlatfileContext)
   useEffect(() => {
     if (!listener) return
 
@@ -19,5 +19,5 @@ export function useListener(
     return () => {
       listener.detach()
     }
-  }, [listener, cb, ...dependencies])
+  }, [listener, accessToken, cb, ...dependencies])
 }

--- a/packages/react/src/hooks/usePlugin.ts
+++ b/packages/react/src/hooks/usePlugin.ts
@@ -6,15 +6,15 @@ export function usePlugin(
   plugin?: (cb: FlatfileListener) => void,
   dependencies: any[] = []
 ) {
-  const { listener } = useContext(FlatfileContext)
+  const { listener, accessToken } = useContext(FlatfileContext)
   useEffect(() => {
     if (!listener) return
-    
+
     if (plugin) {
       listener.use(plugin)
     }
     return () => {
       listener.detach()
     }
-  }, [listener, plugin, ...dependencies])
+  }, [listener, accessToken, plugin, ...dependencies])
 }


### PR DESCRIPTION
Fixes a bug that doesn't re-attach linked listener code when changes to the Browser Driver happen. This happens when the `accessToken` is set after Space creation, so can cause a state where the listener is not attached to the client instance initially if it is not set inline. 

## Example of test:
```tsx
'use client'
import { workbook } from '@/utils/workbook'
import FlatfileListener from '@flatfile/listener'
import { recordHook } from '@flatfile/plugin-record-hook'
import {
  FlatfileProvider,
  Sheet,
  Space,
  useFlatfile,
  useListener
} from '@flatfile/react'
import { useMemo, useState } from 'react'
import styles from './page.module.css'

export const AppWrapper = ({
  PUBLISHABLE_KEY,
}: {
  PUBLISHABLE_KEY: string
}) => {
  const [listenerVersion, setListenerVersion] = useState<number>(0)

  const contactsRecordHooks = [
    (client: FlatfileListener) => {
      client.use(
        recordHook('contacts', (record) => {
          record.set('lastName', 'Listener 1')
          return record
        })
      )
    },
    (client: FlatfileListener) => {
      client.use(
        recordHook('contacts', (record) => {
          record.set('lastName', 'Listener 2')
          return record
        })
      )
    },
    (client: FlatfileListener) => {
      client.use(
        recordHook('contacts', (record) => {
          record.set('lastName', 'Listener 3')
          return record
        })
      )
    },
  ]

  const selectedListener = useMemo(() => {
    return (client: FlatfileListener) => {
      contactsRecordHooks[listenerVersion](client)
    }
  }, [listenerVersion])

  return (
    <FlatfileProvider publishableKey={PUBLISHABLE_KEY}>
      <select
        value={listenerVersion}
        onChange={(e) => setListenerVersion(Number(e.target.value))}
        style={{ marginBottom: '10px' }}
      >
        <option value={0}>Listener 1</option>
        <option value={1}>Listener 2</option>
        <option value={2}>Listener 3</option>
      </select>
      <App selectedListener={selectedListener} />
    </FlatfileProvider>
  )
}

export const App = ({
  selectedListener,
}: {
  selectedListener: (cb: FlatfileListener) => void
}) => {
  const { openPortal } = useFlatfile()

  useListener(selectedListener, [selectedListener])

  return (
    <div className={styles.main}>
      <button onClick={openPortal}>Open Portal</button>
      <Space
        config={{
          name: 'Test Space',
          metadata: {
            sidebarConfig: {
              showSidebar: true,
            },
          },
        }}
      >
        <Sheet
          config={{
            ...workbook.sheets![0],
            slug: 'contacts',
            name: 'Contacts',
          }}
        />
      </Space>
    </div>
  )
}

export default function Home() {
  const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_FLATFILE_PUBLISHABLE_KEY
  if (!PUBLISHABLE_KEY) return <>No Publishable Key Available</>

  return <AppWrapper PUBLISHABLE_KEY={PUBLISHABLE_KEY} />
}

```
