### PR TITLE
feat(JavaScript): allow passing submit complete options

### DIFF
--- a/.changeset/young-peaches-occur.md
+++ b/.changeset/young-peaches-occur.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/embedded-utils': patch
+'@flatfile/javascript': patch
+---
+
+JavaScript: allow specifying submit complete options

--- a/apps/vanilla/cdn.html
+++ b/apps/vanilla/cdn.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Hello, world!</title>
@@ -11,35 +10,50 @@
     <link rel="stylesheet" type="text/css" href="./styles.css" />
 
     <script>
-        start = () => {
-            const { initializeFlatfile: startFlatfile, FlatfileClient } = FlatFileJavaScript
+      const publishableKey =
+        localStorage.getItem('override-publishable-key') ?? 'pk_123456'
 
-            console.log({ FlatfileClient })
-            const flatfileApi = new FlatfileClient({ environment: 'https://platform.eu.flatfile.com/api/v1' })
+      start = () => {
+        const { initializeFlatfile: startFlatfile, FlatfileClient } =
+          FlatFileJavaScript
 
-            startFlatfile({
-                publishableKey: localStorage.getItem('override-publishable-key') ?? 'pk_123456',
-                apiUrl: 'https://platform.eu.flatfile.com/api',
-                spaceBody: {
-                    namespace: "portal",
-                },
-                sheet: blueprint,
-                onSubmit: async ({ event }) => {
-                    console.log('onSubmit', { event })
-                    const {
-                        data,
-                    } = await flatfileApi.files.list({
-                        spaceId: event.context.spaceId,
-                    });
-                    console.log('file', { data });
-                },
-            });
-        };
+        console.log({ FlatfileClient })
+        const flatfileApi = new FlatfileClient({
+          //   environment: 'https://platform.eu.flatfile.com/api/v1',
+        })
+
+        startFlatfile({
+          publishableKey,
+          //   apiUrl: 'https://platform.eu.flatfile.com/api',
+          spaceBody: {
+            namespace: 'portal',
+          },
+          sheet: blueprint,
+          submitSettings: {
+            complete: {
+              acknowledge: true, // required for auto close
+              message: 'Submitting data is now complete!',
+            },
+          },
+          onSubmit: async ({ event }) => {
+            console.log('onSubmit', { event })
+            const { data } = await flatfileApi.files.list({
+              spaceId: event.context.spaceId,
+            })
+            console.log('file', { data })
+          },
+          closeSpace: {
+            operation: 'simpleSubmitAction',
+            onClose: () => {
+              console.log('Portal is now closed!')
+            },
+          },
+        })
+      }
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <button onClick="start()">Open Flatfile</button>
-</body>
-
+  </body>
 </html>

--- a/packages/embedded-utils/src/types/Space.ts
+++ b/packages/embedded-utils/src/types/Space.ts
@@ -101,6 +101,10 @@ export interface ReusedSpaceWithAccessToken extends BaseSpace {
 }
 
 type SubmitSettings = {
+  complete?: {
+    acknowledge?: boolean
+    message?: string
+  }
   deleteSpaceAfterSubmit?: boolean
 }
 export const DefaultSubmitSettings = {

--- a/packages/javascript/src/listener.ts
+++ b/packages/javascript/src/listener.ts
@@ -87,7 +87,8 @@ export const createSimpleListener = ({
 
             await api.jobs.complete(jobId, {
               outcome: {
-                message: 'complete',
+                acknowledge: submitSettings?.complete?.acknowledge ?? false,
+                message: submitSettings?.complete?.message ?? 'complete',
               },
             })
             if (onSubmitSettings.deleteSpaceAfterSubmit) {

--- a/packages/javascript/src/listener.ts
+++ b/packages/javascript/src/listener.ts
@@ -87,7 +87,7 @@ export const createSimpleListener = ({
 
             await api.jobs.complete(jobId, {
               outcome: {
-                acknowledge: submitSettings?.complete?.acknowledge ?? false,
+                acknowledge: submitSettings?.complete?.acknowledge ?? true,
                 message: submitSettings?.complete?.message ?? 'complete',
               },
             })

--- a/packages/javascript/src/startFlatfile.ts
+++ b/packages/javascript/src/startFlatfile.ts
@@ -170,6 +170,7 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
           onRecordHook: simpleOnboardingOptions?.onRecordHook,
           onSubmit: simpleOnboardingOptions?.onSubmit,
           slug: simpleListenerSlug,
+          submitSettings: simpleOnboardingOptions?.submitSettings,
         }),
         closeSpace,
         closeSpaceNow,


### PR DESCRIPTION
Fixes https://github.com/FlatFilers/support-triage/issues/1505

## Please explain how to summarize this PR for the Changelog:

JavaScript: allow specifying submit complete options:

```
submitSettings: {
  complete: {
    acknowledge: true, // if false the message is a toast, if true it's a dialog box
    message: 'Submitting data is now complete!',
  },
},
```

Additionally, setting `submitSettings.complete.acknowledge = true` will allow Portal to be auto closed after the user presses "Continue" with the following settings set (and no `listener`):

```
closeSpace: {
  operation: 'simpleSubmitAction',
  onClose: () => {
    console.log('Portal is now closed!')
  },
},
```

## Tell code reviewer how and what to test:

Test with `apps/vanilla`
