### PR TITLE
fix(react): use a ref for onClose

### DIFF
--- a/.changeset/soft-mangos-bathe.md
+++ b/.changeset/soft-mangos-bathe.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fix bug causing "Maximum update depth exceeded" React error when multiple Portals are used within the same FlatfileProvider (this is not supported).

--- a/apps/react/app/App.tsx
+++ b/apps/react/app/App.tsx
@@ -12,18 +12,21 @@ import {
   usePlugin,
   Workbook,
 } from '@flatfile/react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import styles from './page.module.css'
 
-const App = () => {
-  function logClosed() {
-    console.log('Flatfile Portal closed')
-  }
+const App = ({ id }: { id?: string }) => {
+  const logClosed = useCallback(() => {
+    console.log(`Flatfile Portal ${JSON.stringify(id)} closed`)
+  }, [id])
+  useEffect(() => {
+    console.log('opening portal', { id })
+  }, [id])
   const { open, openPortal, closePortal } = useFlatfile({ onClose: logClosed })
   const [label, setLabel] = useState('Rock')
-  const toggleOpen = () => {
+  const toggleOpen = useCallback(() => {
     open ? closePortal({ reset: false }) : openPortal()
-  }
+  }, [open, closePortal, openPortal])
 
   useEffect(() => {
     openPortal()
@@ -83,7 +86,9 @@ const App = () => {
   return (
     <div className={styles.main}>
       <div className={styles.description}>
-        <button onClick={toggleOpen}>{open ? 'CLOSE' : 'OPEN'} PORTAL</button>
+        <button onClick={toggleOpen}>
+          {open ? 'CLOSE' : 'OPEN'} PORTAL {id}
+        </button>
         <button onClick={() => setLabel('blue')}>blue listener</button>
         <button onClick={() => setLabel('green')}>green listener</button>
       </div>

--- a/apps/react/app/page.tsx
+++ b/apps/react/app/page.tsx
@@ -1,8 +1,7 @@
 'use client'
-import React from 'react'
 
-import App from './App'
 import { FlatfileProvider } from '@flatfile/react'
+import App from './App'
 
 export default function Home() {
   const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_FLATFILE_PUBLISHABLE_KEY
@@ -10,14 +9,25 @@ export default function Home() {
     return <>No Publishable Key Available</>
   }
   return (
-    <FlatfileProvider
-      publishableKey={PUBLISHABLE_KEY}
-      config={{
-        preload: true,
-        styleSheetOptions: { nonce: 'flatfile-abc123' },
-      }}
-    >
-      <App />
-    </FlatfileProvider>
+    <>
+      <FlatfileProvider
+        publishableKey={PUBLISHABLE_KEY}
+        config={{
+          preload: true,
+          styleSheetOptions: { nonce: 'flatfile-abc123' },
+        }}
+      >
+        <App id="1" />
+      </FlatfileProvider>
+      <FlatfileProvider
+        publishableKey={PUBLISHABLE_KEY}
+        config={{
+          preload: true,
+          styleSheetOptions: { nonce: 'flatfile-abc123' },
+        }}
+      >
+        <App id="2" />
+      </FlatfileProvider>
+    </>
   )
 }

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -56,7 +56,7 @@ export interface FlatfileContextType {
   updateSpace: (config: any) => void
   defaultPage: DefaultPageType | undefined
   setDefaultPage: (object: any) => void
-  resetSpace: (options?: ClosePortalOptions, id?: number) => void
+  resetSpace: (options?: ClosePortalOptions) => void
   config?: IFrameTypes
   iframe: RefObject<HTMLIFrameElement>
   ready: boolean

--- a/packages/react/src/components/FlatfileContext.tsx
+++ b/packages/react/src/components/FlatfileContext.tsx
@@ -1,8 +1,14 @@
 import { Flatfile } from '@flatfile/api'
-import FlatfileListener from '@flatfile/listener'
-import { RefObject, createContext, createRef, useContext } from 'react'
-import { IFrameTypes, ClosePortalOptions } from '../types'
 import { DefaultPageType } from '@flatfile/embedded-utils'
+import FlatfileListener from '@flatfile/listener'
+import {
+  MutableRefObject,
+  RefObject,
+  createContext,
+  createRef,
+  useContext,
+} from 'react'
+import { ClosePortalOptions, IFrameTypes } from '../types'
 
 type CreateNewSpace = Partial<Flatfile.SpaceConfig>
 type ReUseSpace = Partial<Flatfile.SpaceConfig> & {
@@ -28,8 +34,7 @@ export interface FlatfileContextType {
   environmentId?: string
   apiUrl: string
   open: boolean
-  onClose?: () => void
-  setOnClose: (onClose: () => undefined | (() => void)) => void
+  onClose: MutableRefObject<null | undefined | (() => void)>
   setOpen: (open: boolean) => void
   space?: CreateNewSpace | ReUseSpace
   sessionSpace?: any
@@ -51,7 +56,7 @@ export interface FlatfileContextType {
   updateSpace: (config: any) => void
   defaultPage: DefaultPageType | undefined
   setDefaultPage: (object: any) => void
-  resetSpace: (options?: ClosePortalOptions) => void
+  resetSpace: (options?: ClosePortalOptions, id?: number) => void
   config?: IFrameTypes
   iframe: RefObject<HTMLIFrameElement>
   ready: boolean
@@ -62,8 +67,7 @@ export const FlatfileContext = createContext<FlatfileContextType>({
   environmentId: undefined,
   apiUrl: '',
   open: true,
-  onClose: undefined,
-  setOnClose: () => {},
+  onClose: createRef<(() => void) | undefined>(),
   setOpen: () => {},
   space: undefined,
   sessionSpace: undefined,

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -247,7 +247,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     }))
   }
 
-  const resetSpace = ({ reset }: ClosePortalOptions = {}, id?: number) => {
+  const resetSpace = ({ reset }: ClosePortalOptions = {}) => {
     setOpen(false)
 
     if (reset ?? FLATFILE_PROVIDER_CONFIG.resetOnClose) {

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -22,10 +22,7 @@ import FlatfileContext, {
   FlatfileContextType,
 } from './FlatfileContext'
 
-import {
-  attachStyleSheet,
-  useAttachStyleSheet,
-} from '../utils/attachStyleSheet'
+import { useAttachStyleSheet } from '../utils/attachStyleSheet'
 import { workbookOnSubmitAction } from '../utils/constants'
 
 const configDefaults: IFrameTypes = {
@@ -48,6 +45,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
   apiUrl = 'https://platform.flatfile.com/api',
   config,
 }) => {
+  const onClose = useRef<undefined | (() => void)>()
   useAttachStyleSheet(config?.styleSheetOptions)
   const [internalAccessToken, setInternalAccessToken] = useState<
     string | undefined | null
@@ -63,8 +61,6 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     workbook?: Flatfile.CreateWorkbookConfig
     space: Flatfile.SpaceConfig & { id?: string }
   }>(DEFAULT_CREATE_SPACE)
-
-  const [onClose, setOnClose] = useState<undefined | (() => void)>()
 
   const iframe = useRef<HTMLIFrameElement>(null)
 
@@ -251,7 +247,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
     }))
   }
 
-  const resetSpace = ({ reset }: ClosePortalOptions = {}) => {
+  const resetSpace = ({ reset }: ClosePortalOptions = {}, id?: number) => {
     setOpen(false)
 
     if (reset ?? FLATFILE_PROVIDER_CONFIG.resetOnClose) {
@@ -272,8 +268,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       }
       // Works but only after the iframe is visible
     }
-
-    onClose?.()
+    onClose.current?.()
   }
 
   // Listen to the postMessage event from the created iFrame
@@ -336,7 +331,6 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       environmentId,
       open,
       onClose,
-      setOnClose,
       setOpen,
       sessionSpace,
       setSessionSpace,
@@ -372,7 +366,6 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       iframe,
       FLATFILE_PROVIDER_CONFIG,
       onClose,
-      setOnClose,
     ]
   )
 

--- a/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
+++ b/packages/react/src/components/_tests_/FlatfileProvider.spec.tsx
@@ -1,20 +1,19 @@
-import React, { createRef, useContext } from 'react'
+import FlatfileListener from '@flatfile/listener'
 import { render, waitFor } from '@testing-library/react'
-import { FlatfileProvider } from '../FlatfileProvider'
+import fetchMock from 'jest-fetch-mock'
+import React, { createRef, useContext } from 'react'
 import FlatfileContext, {
   DEFAULT_CREATE_SPACE,
   FlatfileContextType,
 } from '../FlatfileContext'
-import fetchMock from 'jest-fetch-mock'
-import FlatfileListener from '@flatfile/listener'
+import { FlatfileProvider } from '../FlatfileProvider'
 
 export const FlatfileProviderValue: FlatfileContextType = {
   updateDocument: jest.fn(),
   apiUrl: '',
   open: false,
   setOpen: jest.fn(),
-  onClose: undefined,
-  setOnClose: jest.fn(),
+  onClose: createRef<undefined | (() => void)>(),
   setSessionSpace: jest.fn(),
   listener: new FlatfileListener(),
   setListener: jest.fn(),

--- a/packages/react/src/hooks/useFlatfile.ts
+++ b/packages/react/src/hooks/useFlatfile.ts
@@ -19,16 +19,11 @@ export const useFlatfile: (useFlatfileOptions?: UseFlatfileOptions) => {
     throw new Error('useFlatfile must be used within a FlatfileProvider')
   }
 
-  const onCloseCallback = useCallback(
-    useFlatfileOptions.onClose ?? (() => {}),
-    [typeof useFlatfileOptions.onClose]
-  )
-
   useEffect(() => {
-    if (context.onClose !== onCloseCallback) {
-      context.setOnClose(() => onCloseCallback)
+    if (context.onClose.current !== useFlatfileOptions.onClose) {
+      context.onClose.current = useFlatfileOptions.onClose
     }
-  }, [context.onClose, context.setOnClose, onCloseCallback])
+  }, [context.onClose.current, useFlatfileOptions.onClose])
 
   const { open, setOpen, setListener, listener, apiUrl, resetSpace, ready } =
     context


### PR DESCRIPTION
Fixes https://github.com/FlatFilers/support-triage/issues/1513

## Please explain how to summarize this PR for the Changelog:

Fix bug causing "Maximum update depth exceeded" React error when multiple Portals are used within the same FlatfileProvider (this is not supported).

## Tell code reviewer how and what to test:

`apps/react` now has two separate `<FlatfileProvider>` and `useFlatfile()` instances, this can be tested to see that the bug does not occur and the Portals behave independently.

The main issue was two `useFlatfile` hooks sharing the same FlatfileContext, however that is still not possible even after this PR, since the Context can only hold one state.

Replacing the `onClose` state with a mutable ref prevents the "Maximum update depth exceeded" error.