### PR TITLE
feat(react): allow specifying submitSettings.startingJobMessage

### DIFF
--- a/.changeset/witty-cobras-sniff.md
+++ b/.changeset/witty-cobras-sniff.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/embedded-utils': patch
+'@flatfile/react': patch
+---
+
+Added option submitSettings startingJobMessage to configure the initial message displayed in the job progress modal.

--- a/apps/react/app/sheet/App.tsx
+++ b/apps/react/app/sheet/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
         }}
       />
 
-      {/* <Sheet
+      <Sheet
         config={{ ...sheet, slug: 'second-sheet', name: 'Second Sheet' }}
         onRecordHook={(record) => {
           const email = record.get('email')
@@ -82,7 +82,7 @@ const App = () => {
           }
           return record
         }}
-      /> */}
+      />
     </div>
   )
 }

--- a/apps/react/app/sheet/App.tsx
+++ b/apps/react/app/sheet/App.tsx
@@ -68,10 +68,13 @@ const App = () => {
         onSubmit={(sheet) => {
           console.log('onSubmit from Sheet Action', { sheet })
         }}
+        submitSettings={{
+          startingJobMessage: 'Custom submit message',
+        }}
       />
 
-      <Sheet
-        config={{...sheet, slug: 'second-sheet', name: 'Second Sheet'}}
+      {/* <Sheet
+        config={{ ...sheet, slug: 'second-sheet', name: 'Second Sheet' }}
         onRecordHook={(record) => {
           const email = record.get('email')
           if (!email) {
@@ -79,7 +82,7 @@ const App = () => {
           }
           return record
         }}
-      />
+      /> */}
     </div>
   )
 }

--- a/apps/react/app/workbook/App.tsx
+++ b/apps/react/app/workbook/App.tsx
@@ -29,6 +29,9 @@ const App = () => {
         onSubmit={async (sheet) => {
           console.log('on Workbook Submit ', { sheet })
         }}
+        submitSettings={{
+          startingJobMessage: 'Custom workbook submit',
+        }}
         onRecordHooks={[
           [
             'contacts',

--- a/packages/embedded-utils/src/types/Space.ts
+++ b/packages/embedded-utils/src/types/Space.ts
@@ -106,6 +106,7 @@ type SubmitSettings = {
     message?: string
   }
   deleteSpaceAfterSubmit?: boolean
+  startingJobMessage?: string | null
 }
 export const DefaultSubmitSettings = {
   deleteSpaceAfterSubmit: false,

--- a/packages/react/src/utils/constants.ts
+++ b/packages/react/src/utils/constants.ts
@@ -28,10 +28,13 @@ export const OnSubmitAction = (
     const FlatfileAPI = new FlatfileClient()
     try {
       await FlatfileAPI.jobs.ack(jobId, {
-        info: 'Starting job',
+        // pass null to omit info, otherwise string or undefined for default 'Starting job' message
+        info:
+          onSubmitSettings?.startingJobMessage === null
+            ? undefined
+            : onSubmitSettings?.startingJobMessage ?? 'Starting job',
         progress: 10,
       })
-
       const job = new JobHandler(jobId)
       const { data: workbookSheets } = await FlatfileAPI.sheets.list({
         workbookId,


### PR DESCRIPTION
Fixes https://github.com/FlatFilers/support-triage/issues/1608

## Please explain how to summarize this PR for the Changelog:

Added option submitSettings startingJobMessage to configure the initial message displayed in the job progress modal.

## Tell code reviewer how and what to test:

Test apps/react with various `submitSettings={{ startingJobMessage }}` props.
