### PR TITLE
Feat: Add getErrors public method on FlatfileRecord class

### DIFF
--- a/.changeset/mean-buckets-relate.md
+++ b/.changeset/mean-buckets-relate.md
@@ -2,4 +2,4 @@
 '@flatfile/hooks': minor
 ---
 
-Added public getErrors method on the FlatfileRecord class
+Added public `getErrors()` method on the FlatfileRecord class

--- a/.changeset/mean-buckets-relate.md
+++ b/.changeset/mean-buckets-relate.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/hooks': minor
+---
+
+Added public getErrors method on the FlatfileRecord class

--- a/package-lock.json
+++ b/package-lock.json
@@ -36124,7 +36124,7 @@
     },
     "packages/configure": {
       "name": "@flatfile/configure",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/hooks": "^1.5.0",
@@ -39559,7 +39559,7 @@
     },
     "packages/listener": {
       "name": "@flatfile/listener",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -125,6 +125,20 @@ describe('FlatfileRecord', () => {
     const errors = person.getErrors()
     expect(errors.length).toBe(2)
     expect(errors.every((e) => e.level === 'error')).toBe(true)
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'name',
+          message: 'Invalid name',
+          level: 'error',
+        }),
+        expect.objectContaining({
+          field: 'age',
+          message: 'Invalid age',
+          level: 'error',
+        }),
+      ])
+    )
   })
 
   it('returns the errors for a specific field', () => {
@@ -149,6 +163,20 @@ describe('FlatfileRecord', () => {
     const errors = person.getErrors(['name', 'age'])
     expect(errors.length).toBe(2)
     expect(errors.every((e) => e.level === 'error')).toBe(true)
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'name',
+          message: 'Invalid name',
+          level: 'error',
+        }),
+        expect.objectContaining({
+          field: 'age',
+          message: 'Invalid age',
+          level: 'error',
+        }),
+      ])
+    )
   })
 
   it('should return an empty array if the field does not exist', () => {
@@ -157,6 +185,14 @@ describe('FlatfileRecord', () => {
 
     const error = person.getErrors('lastName')
     expect(error).toEqual([])
+  })
+
+  it('should return an empty array for multiple non-existent fields', () => {
+    person.addError('name', 'Invalid name')
+    person.addError('age', 'Invalid age')
+
+    const errors = person.getErrors(['lastName', 'email'])
+    expect(errors).toEqual([])
   })
 
   it('does not return an updated record if a record value that does not exist is changed', () => {

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -93,6 +93,20 @@ describe('FlatfileRecord', () => {
     })
   })
 
+  it('returns the errors for a record', () => {
+    person.addInfo('name', 'Rad name')
+    person.addError('age', 'So immature')
+
+    const errors = person.getErrors()
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toEqual({
+      field: 'age',
+      message: 'So immature',
+      level: 'error',
+      stage: 'other',
+    })
+  })
+
   it('does not return an updated record if a record value that does not exist is changed', () => {
     person.set('job', 'engineer')
 

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -107,6 +107,23 @@ describe('FlatfileRecord', () => {
     })
   })
 
+  it('returns an empty array when there are no errors', () => {
+    person.addInfo('name', 'Rad name')
+    person.addInfo('age', 'What a name')
+
+    const errors = person.getErrors()
+    expect(errors.length).toBe(0)
+  })
+
+  it('returns multiple errors for a record', () => {
+    person.addError('name', 'Invalid name')
+    person.addError('age', 'Invalid age')
+
+    const errors = person.getErrors()
+    expect(errors.length).toBe(2)
+    expect(errors.every((e) => e.level === 'error')).toBe(true)
+  })
+
   it('does not return an updated record if a record value that does not exist is changed', () => {
     person.set('job', 'engineer')
 

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -95,6 +95,8 @@ describe('FlatfileRecord', () => {
 
   it('returns the errors for a record', () => {
     person.addInfo('name', 'Rad name')
+    person.addWarning('age', 'What a name')
+    person.addComment('age', 'What a name')
     person.addError('age', 'So immature')
 
     const errors = person.getErrors()
@@ -109,7 +111,8 @@ describe('FlatfileRecord', () => {
 
   it('returns an empty array when there are no errors', () => {
     person.addInfo('name', 'Rad name')
-    person.addInfo('age', 'What a name')
+    person.addWarning('age', 'What a name')
+    person.addComment('age', 'What a name')
 
     const errors = person.getErrors()
     expect(errors.length).toBe(0)

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -151,6 +151,14 @@ describe('FlatfileRecord', () => {
     expect(errors.every((e) => e.level === 'error')).toBe(true)
   })
 
+  it('should return an empty array if the field does not exist', () => {
+    person.addError('name', 'Invalid name')
+    person.addError('age', 'Invalid age')
+
+    const error = person.getErrors('lastName')
+    expect(error).toEqual([])
+  })
+
   it('does not return an updated record if a record value that does not exist is changed', () => {
     person.set('job', 'engineer')
 

--- a/packages/hooks/src/classes/FlatfileRecord.spec.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.spec.ts
@@ -127,6 +127,30 @@ describe('FlatfileRecord', () => {
     expect(errors.every((e) => e.level === 'error')).toBe(true)
   })
 
+  it('returns the errors for a specific field', () => {
+    person.addError('name', 'Invalid name')
+    person.addError('age', 'Invalid age')
+
+    const error = person.getErrors('name')
+    expect(error).toEqual([
+      {
+        field: 'name',
+        message: 'Invalid name',
+        level: 'error',
+        stage: 'other',
+      },
+    ])
+  })
+
+  it('returns the errors for specific fields', () => {
+    person.addError('name', 'Invalid name')
+    person.addError('age', 'Invalid age')
+
+    const errors = person.getErrors(['name', 'age'])
+    expect(errors.length).toBe(2)
+    expect(errors.every((e) => e.level === 'error')).toBe(true)
+  })
+
   it('does not return an updated record if a record value that does not exist is changed', () => {
     person.set('job', 'engineer')
 

--- a/packages/hooks/src/classes/FlatfileRecord.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.ts
@@ -232,7 +232,16 @@ export class FlatfileRecord<
   /**
    * Returns an array of the error-level messages for the record
    */
-  public getErrors(): IRecordInfo<M>[] {
+  public getErrors(fields?: keyof M | (keyof M)[]): IRecordInfo<M>[] {
+    if (fields) {
+      const fieldsArray = Array.isArray(fields)
+        ? fields
+        : [fields].filter(Boolean)
+      return this._info.filter(
+        (info) => info.level === 'error' && fieldsArray.includes(info.field)
+      )
+    }
+
     return this._info.filter((info) => info.level === 'error')
   }
 

--- a/packages/hooks/src/classes/FlatfileRecord.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.ts
@@ -229,6 +229,9 @@ export class FlatfileRecord<
     return null
   }
 
+  /**
+   * Returns an array of the error-level messages for the record
+   */
   public getErrors(): IRecordInfo<M>[] {
     return this._info.filter((info) => info.level === 'error')
   }

--- a/packages/hooks/src/classes/FlatfileRecord.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.ts
@@ -231,6 +231,19 @@ export class FlatfileRecord<
 
   /**
    * Returns an array of the error-level messages for the record
+   * @param fields - Optional field or array of fields to filter errors by
+   * @returns Array of error messages with level 'error'
+   * @example
+   * ```typescript
+   * // Get all errors
+   * const allErrors = record.getErrors();
+   * 
+   * // Get errors for specific field
+   * const nameErrors = record.getErrors('name');
+   * 
+   * // Get errors for multiple fields
+   * const errors = record.getErrors(['name', 'age']);
+   * ```
    */
   public getErrors(fields?: keyof M | (keyof M)[]): IRecordInfo<M>[] {
     if (fields) {

--- a/packages/hooks/src/classes/FlatfileRecord.ts
+++ b/packages/hooks/src/classes/FlatfileRecord.ts
@@ -229,6 +229,10 @@ export class FlatfileRecord<
     return null
   }
 
+  public getErrors(): IRecordInfo<M>[] {
+    return this._info.filter((info) => info.level === 'error')
+  }
+
   public getMetadata(): Object {
     return this.metadata
   }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Added public `getErrors` method on the FlatfileRecord class.

## Tell code reviewer how and what to test:

Add an error to a field. Then call `getErrors` to see the error returned.