### PR TITLE
Fix: v2-shims configToBlueprint not converting fields with type number

### DIFF
--- a/packages/v2-shims/src/plugins/config.to.blueprint.spec.ts
+++ b/packages/v2-shims/src/plugins/config.to.blueprint.spec.ts
@@ -132,5 +132,22 @@ describe('v2ConfigToBlueprint', () => {
     ])
   })
 
+  it('should convert number field type to number', async () => {
+    const input: ISettings = {
+      type: 'Sample',
+      fields: [
+        {
+          key: 'sampleKey',
+          label: 'sampleLabel',
+          type: 'number', 
+        },
+      ],
+    };
+  
+    const result = await configToBlueprint(input);
+  
+    expect(result.sheets[0].fields[0].type).toBe(PlatformTypes.Num); 
+  });
+
   // You can also add negative tests, like testing how the function behaves with invalid input
 })

--- a/packages/v2-shims/src/plugins/config.to.blueprint.ts
+++ b/packages/v2-shims/src/plugins/config.to.blueprint.ts
@@ -26,6 +26,8 @@ export const configToBlueprint = (schema: ISettings): BlueprintOutput => {
       if (field.type === 'select') {
         out.type = PlatformTypes.Enum
         out.config = { options: field.options }
+      } else if (field.type === 'number') {
+        out.type = PlatformTypes.Num; 
       }
     }
     if (field.validators) {

--- a/packages/v2-shims/src/types/settings.interface.ts
+++ b/packages/v2-shims/src/types/settings.interface.ts
@@ -151,7 +151,7 @@ export interface IFieldBase {
   shortDescription?: string
   alternates?: string[]
   validators?: IValidator[]
-  type?: 'checkbox' | 'string'
+  type?: 'checkbox' | 'string' | 'number'
   sizeHint?: number
 }
 


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
* Added support for handling number field types in the `configToBlueprint` function.
* Ensures that fields with type: 'number' are correctly converted to `PlatformTypes.Num`

## Tell code reviewer how and what to test:
Verify that the configToBlueprint function correctly processes fields with type: 'number'.
how it's currently behaving before the fix:

```
// input
propertyValue: { type: 'number', label: 'Property Value', minimum: 0 },

// output
{key: 'propertyValue', label: 'Property Value', type: 'string', constraints: Array(0)}
```

expected:
```
// input
propertyValue: { type: 'number', label: 'Property Value', minimum: 0 },

// output
{key: 'propertyValue', label: 'Property Value', type: 'number', constraints: Array(0)}
```