### PR TITLE
Fix packages/react close modal width issue on small screens

### DIFF
--- a/packages/react/src/components/style.scss
+++ b/packages/react/src/components/style.scss
@@ -156,7 +156,6 @@
   tab-size: 4;
   text-align: left;
   background: #fff;
-  min-width: 500px;
   max-width: 500px;
 }
 .flatfile_close-confirm-modal-inner {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Fixes the size of the close confirmation modal on very small screens

## Tell code reviewer how and what to test:

1. Using packages/react
2. Try to close the Flatfile modal on a screen size that is very small. 
   - In the previous version, it would go beyond the borders of the screen (min-width > screen width)
   - In the new version, it should be contained within the screen
   - 
| BEFORE | AFTER |
| -------- | ------- |
|<img width="522" alt="2" src="https://github.com/user-attachments/assets/944000bd-a8f9-46b0-b1a0-203799e8a83a" />|<img width="424" alt="3" src="https://github.com/user-attachments/assets/3f3e48bc-869e-46d6-8d55-5c2384cf52bb" />| 
