### PR TITLE
Remove title from <iframe /> container

### DIFF
--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -114,7 +114,6 @@ export const EmbeddedIFrameWrapper = (
         data-testid={mountElement}
         ref={iframe}
         src={iframeSrc}
-        title="Embedded Portal Content"
         style={{
           ...getIframeStyles(iframeStyles!),
           ...(preload ? openVisible(open) : { opacity: 1 }),

--- a/packages/react/src/components/legacy/InitSpace.tsx
+++ b/packages/react/src/components/legacy/InitSpace.tsx
@@ -201,7 +201,6 @@ export const InitSpace = (props: IReactInitSpaceProps): JSX.Element => {
             data-testid={mountElement}
             src={spaceUrl}
             style={getIframeStyles(iframeStyles!)}
-            title="Embedded Portal Content"
           />
           <button
             onClick={() => setShowExitWarnModal(true)}

--- a/packages/react/src/components/legacy/LegacySpace.tsx
+++ b/packages/react/src/components/legacy/LegacySpace.tsx
@@ -127,7 +127,6 @@ export const SpaceContents = (
         data-testid={mountElement}
         src={spaceUrl}
         style={getIframeStyles(iframeStyles!)}
-        title="Embedded Portal Content"
       />
       <button
         onClick={() => setShowExitWarnModal(true)}

--- a/packages/vue/src/components/SpaceC.vue
+++ b/packages/vue/src/components/SpaceC.vue
@@ -22,7 +22,6 @@
       :style="getIframeStyles(iframeStyles)"
       allow="clipboard-read; clipboard-write"
       id="flatfile_iframe"
-      title="Embedded Portal Content"
     ></iframe>
     <div
       @click="showExitWarnModal = true"


### PR DESCRIPTION
## Overview

On Firefox, a tooltip appears when hovering clickable elements inside the iframe with the "title" attribute of the iframe. Hovering over the an action button "Submit", for example, would show "Embedded Portal Content", which was distracting. Removing the title should solve the issue.

On Chrome, this tooltip was visible only when hovering the edges of the iframe, not the content itself.

### Screenshot of the issue

![2190-2320-6733-7e022d2b6f5d](https://github.com/user-attachments/assets/249088f2-a416-45f6-ba57-71c9d679a017)

## Please explain how to summarize this PR for the Changelog:

A fix that removes the title tooltip of Flatfile's iframe, that was causing a tooltip "Embedded Portal Contents" to appear in some browsers (affected mainly Firefox)

## Tell code reviewer how and what to test:

- Open Firefox with the current version of the libs, and hover clickable elements until the tooltip "Embedded Portal Contents" appears
- Open Firefox with *this* version of the libs, and the tooltip should be gone

## Workaround

We are currently using a `useFlatfileIframeTitleRemover` React hook, that observes DOM changes for the iframe being injected, and remove it's title attribute if necessary.

```
import { useEffect } from 'react'

/**
 * The <iframe class="flatfile_iFrameContainer" /> injected by Flatfile has a
 * title attribute that causes a tooltip to appear when hovering some elements.
 *
 * @note This is particularly noticeable in Firefox (clickables will show a tooltip)
 * On Chrome, it appears when hovering the borders of the iframe.
 *
 * @see https://github.com/FlatFilers/flatfile-core-libraries/blob/6773e36c90fdfedc3da50aeaafa3e85f1c4dbabd/packages/react/src/components/EmbeddedIFrameWrapper.tsx#L117 for original implementation. It might change.
 */
export function useFlatfileIframeTitleRemover(
  selector = '.flatfile_iFrameContainer',
  targetTitle = 'Embedded Portal Content',
) {
  // Creates a mutation observer that queries for Flatfile's iframe
  // and removes its title, if it matches the title we expect
  useEffect(() => {
    if (typeof MutationObserver === 'undefined') {
      // ignore this hook if the browser doesn't support MutationObserver
      return
    }

    const removeIframeTitle = () => {
      const iframe = document.querySelector(selector) as HTMLIFrameElement

      if (
        iframe &&
        iframe.tagName === 'IFRAME' &&
        iframe.title === targetTitle
      ) {
        iframe.removeAttribute('title')
      }
    }

    removeIframeTitle()

    const observer = new MutationObserver((mutations) => {
      mutations.forEach((mutation) => {
        if (mutation.type === 'childList') {
          removeIframeTitle()
        }
      })
    })

    observer.observe(document.body, {
      childList: true,
      subtree: true,
    })

    return () => observer.disconnect()
  }, [selector, targetTitle])
}
```