### PR TITLE
Add some missing parameters to space creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31538,7 +31538,7 @@
     },
     "packages/angular/angular-sdk": {
       "name": "@flatfile/angular-sdk",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@flatfile/embedded-utils": "^1.2.3",

--- a/packages/angular/angular-sdk/package.json
+++ b/packages/angular/angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/angular-sdk",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "homepage": "https://flatfile.com/",
   "description": "Flatfile SDK for Angular",
   "license": "MIT",

--- a/packages/angular/angular-sdk/package.json
+++ b/packages/angular/angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/angular-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "https://flatfile.com/",
   "description": "Flatfile SDK for Angular",
   "license": "MIT",

--- a/packages/angular/angular-sdk/src/lib/sdk/space.service.ts
+++ b/packages/angular/angular-sdk/src/lib/sdk/space.service.ts
@@ -42,6 +42,10 @@ export class SpaceService {
     }
 
     const {
+      name,
+      namespace,
+      languageOverride,
+      translationsPath,
       workbook,
       document,
       themeConfig,
@@ -60,6 +64,10 @@ export class SpaceService {
     }
 
     return initNewSpace({
+      name,
+      namespace,
+      languageOverride,
+      translationsPath,
       publishableKey,
       workbook: createdWorkbook,
       document,
@@ -117,7 +125,7 @@ export class SpaceService {
         apiUrl: spaceProps.apiUrl,
         workbook: spaceProps.workbook || this.spaceResponse.workbooks?.[0],
       }
-
+      console.dir(formattedSpaceProps, { depth: null })
       this._spaceInitialized.set(formattedSpaceProps)
       this._loading.set(false)
       return formattedSpaceProps

--- a/packages/angular/angular-sdk/src/lib/sdk/space.service.ts
+++ b/packages/angular/angular-sdk/src/lib/sdk/space.service.ts
@@ -125,7 +125,6 @@ export class SpaceService {
         apiUrl: spaceProps.apiUrl,
         workbook: spaceProps.workbook || this.spaceResponse.workbooks?.[0],
       }
-      console.dir(formattedSpaceProps, { depth: null })
       this._spaceInitialized.set(formattedSpaceProps)
       this._loading.set(false)
       return formattedSpaceProps


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
Parameters were missing from the props passed to initNewSpace() for the Angular SDK.
## Tell code reviewer how and what to test:
Confirm that custom name and languageOverride settings are correctly set on the space.