### PR TITLE
Update css for close button to prevent overlap

### DIFF
--- a/packages/react/src/components/CloseButton.tsx
+++ b/packages/react/src/components/CloseButton.tsx
@@ -11,19 +11,13 @@ export const CloseButton = ({
     type="button"
     className="flatfile-close-button"
     aria-label="Close"
-    style={{
-      position: 'absolute',
-      margin: '30px',
-      top: '30px',
-      right: '30px',
-    }}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
+      width="20"
+      height="20"
       viewBox="0 0 100 100"
-      style={{ margin: 'auto' }}
+      style={{ margin: 'auto', display: 'block' }}
     >
       <line x1="10" y1="10" x2="90" y2="90" stroke="white" strokeWidth="10" />
       <line x1="10" y1="90" x2="90" y2="10" stroke="white" strokeWidth="10" />

--- a/packages/react/src/components/style.scss
+++ b/packages/react/src/components/style.scss
@@ -59,19 +59,19 @@
 }
 .flatfile-close-button {
   position: relative;
-  top: 20px;
-  right: -20px;
-  width: 25px;
-  height: 25px;
-  border-radius: 100%;
+  top: 0px;
+  right: 20px;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
   cursor: pointer;
   border: none;
   background: rgb(29, 31, 74);
-  box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.5);
+  box-shadow: none;
   transition: 0.25s ease-in-out;
 
   &:hover {
-    box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.8);
+    background: #3c3c3c;
   }
 }
 .flatfile_button-group {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Updates css of close button to prevent overlap

<img width="1664" alt="Screenshot 2025-03-07 at 12 22 27 AM" src="https://github.com/user-attachments/assets/6dd3dade-8dc9-43e0-a579-40c0594489df" />


## Tell code reviewer how and what to test:

