### PR TITLE
allow sync-xhr requests to self and *.flatfile.com domains in the iframe

### DIFF
--- a/.changeset/twelve-planes-relate.md
+++ b/.changeset/twelve-planes-relate.md
@@ -1,0 +1,7 @@
+---
+'@flatfile/javascript': patch
+'@flatfile/react': patch
+'@flatfile/vue': patch
+---
+
+Update sync-xhr settings for embedded iframe

--- a/packages/javascript/src/createIframe.ts
+++ b/packages/javascript/src/createIframe.ts
@@ -34,7 +34,7 @@ export function createIframe(
   const iframe = document.createElement('iframe')
   iframe.src = url
   iframe.id = 'flatfile_iframe'
-  iframe.allow = 'clipboard-read; clipboard-write'
+  iframe.allow = "clipboard-read; clipboard-write; sync-xhr 'self' '*.flatfile.com'"
   // Create the wrapper
   const wrapper = document.createElement('div')
   wrapper.classList.add('flatfile_iframe-wrapper')

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -109,7 +109,7 @@ export const EmbeddedIFrameWrapper = (
         />
       )}
       <iframe
-        allow="clipboard-read; clipboard-write"
+        allow="clipboard-read; clipboard-write; sync-xhr 'self' '*.flatfile.com'"
         className={mountElement}
         data-testid={mountElement}
         ref={iframe}

--- a/packages/react/src/components/legacy/InitSpace.tsx
+++ b/packages/react/src/components/legacy/InitSpace.tsx
@@ -196,7 +196,7 @@ export const InitSpace = (props: IReactInitSpaceProps): JSX.Element => {
       {!initError && !unmountIFrame && (
         <>
           <iframe
-            allow="clipboard-read; clipboard-write"
+            allow="clipboard-read; clipboard-write; sync-xhr 'self' '*.flatfile.com'"
             className={mountElement}
             data-testid={mountElement}
             src={spaceUrl}

--- a/packages/react/src/components/legacy/LegacySpace.tsx
+++ b/packages/react/src/components/legacy/LegacySpace.tsx
@@ -122,7 +122,7 @@ export const SpaceContents = (
         />
       )}
       <iframe
-        allow="clipboard-read; clipboard-write"
+        allow="clipboard-read; clipboard-write; sync-xhr 'self' '*.flatfile.com'"
         className={mountElement}
         data-testid={mountElement}
         src={spaceUrl}

--- a/packages/vue/src/components/SpaceC.vue
+++ b/packages/vue/src/components/SpaceC.vue
@@ -20,7 +20,7 @@
       :data-testid="mountElement"
       :src="spaceUrl"
       :style="getIframeStyles(iframeStyles)"
-      allow="clipboard-read; clipboard-write"
+      allow="clipboard-read; clipboard-write; sync-xhr 'self' '*.flatfile.com'"
       id="flatfile_iframe"
       title="Embedded Portal Content"
     ></iframe>


### PR DESCRIPTION
this (hopefully) fixes an issue encountered by customers using an embedded space in a setup where the parent html page is being served with a `Permissions-Policy: sync-xhr()` policy, which causes the browser to block synchronous http requests from the iframe. This matters because the embedded spaces-ui now needs to make a synchronous request to `https://cdn.flatfile.com/config/spaces-ui/platform.flatfile.com.config.js` in order to fetch the frontend config, which has to happen synchronous so the config vars are available prior to loading the react app. 

the fix will also require the customer to set their `Permissions-Policy: sync-xhr('self' '*.flatfile.com')` to allow the request. The iframe.allow attribute has to agree with the server policy. 
