### PR TITLE
Use spaceUrl for existing spaces

### DIFF
--- a/.changeset/spicy-moons-provide.md
+++ b/.changeset/spicy-moons-provide.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/react': patch
+---
+
+Fixes issue when using spaceUrl with an existing space

--- a/packages/react/src/components/FlatfileProvider.tsx
+++ b/packages/react/src/components/FlatfileProvider.tsx
@@ -129,6 +129,7 @@ export const FlatfileProvider: React.FC<ExclusiveFlatfileProviderProps> = ({
       const { data: reUsedSpace } = await getSpace({
         space: { id: createSpace.space.id, accessToken: internalAccessToken },
         apiUrl,
+        spaceUrl: config?.spaceUrl,
       })
       debugLogger('Found space:', { reUsedSpace })
 

--- a/packages/react/src/utils/getSpace.tsx
+++ b/packages/react/src/utils/getSpace.tsx
@@ -32,7 +32,10 @@ export const getSpace = async (
     }
 
     if (!spaceResponse.data.guestLink) {
-      const guestLink = `${spaceUrl}space/${space?.id}?token=${spaceResponse.data.accessToken}`
+      const normalizedSpaceUrl = spaceUrl.endsWith('/')
+        ? spaceUrl.slice(0, -1)
+        : spaceUrl
+      const guestLink = `${normalizedSpaceUrl}/space/${space?.id}?token=${spaceResponse.data.accessToken}`
       spaceResponse.data.guestLink = guestLink
     }
 


### PR DESCRIPTION
The `spaceUrl` setting was not being respected when using existing spaces, this makes sure it is.

Also makes sure we handle space urls without a trailing slash, since I think no trailing slash is consistent with how we configure them elsewhere and I'm not sure which one Nexl is using.