### PR TITLE
Retry space init postMessage until acked

### DIFF
--- a/.changeset/cool-cougars-confess.md
+++ b/.changeset/cool-cougars-confess.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/javascript': minor
+'@flatfile/react': minor
+---
+
+Improved handling for preloading portal iframes

--- a/packages/javascript/src/startFlatfile.ts
+++ b/packages/javascript/src/startFlatfile.ts
@@ -227,14 +227,17 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
       window.addEventListener('message', messageListener)
 
       // Function to send initialize message with retry logic
-      const sendInitializeMessage = (retryCount = 0) => {
+      const sendInitializeMessage = (retryCount = 0, messageId?: string) => {
         if (!mountIFrameElement?.contentWindow) {
           return
         }
 
-        const messageId = `init_${Date.now()}_${Math.random()
-          .toString(36)
-          .substring(2, 11)}`
+        // Generate messageId only on first attempt
+        if (!messageId) {
+          messageId = `init_${Date.now()}_${Math.random()
+            .toString(36)
+            .substring(2, 11)}`
+        }
 
         // Don't send if already acknowledged
         if (acknowledgedMessages.has(messageId)) {
@@ -269,11 +272,11 @@ export async function startFlatfile(options: SimpleOnboarding | ISpace) {
           const retryDelay = Math.min(500 * Math.pow(2, retryCount), 8000) // Cap at 8 seconds
           const timeoutId = setTimeout(() => {
             retryTimeouts.delete(timeoutId as unknown as number)
-            if (!acknowledgedMessages.has(messageId)) {
+            if (!acknowledgedMessages.has(messageId!)) {
               console.debug(
                 `No acknowledgment received for messageId ${messageId}, retrying...`
               )
-              sendInitializeMessage(retryCount + 1)
+              sendInitializeMessage(retryCount + 1, messageId)
             }
           }, retryDelay) as unknown as number
 

--- a/packages/react/src/components/EmbeddedIFrameWrapper.tsx
+++ b/packages/react/src/components/EmbeddedIFrameWrapper.tsx
@@ -43,7 +43,7 @@ export const EmbeddedIFrameWrapper = (
   const acknowledgedMessagesRef = useRef<Set<string>>(new Set())
 
   const sendInitializeMessage = useCallback(
-    (retryCount = 0) => {
+    (retryCount = 0, messageId?: string) => {
       if (
         !sessionSpace?.space?.id ||
         !sessionSpace?.space?.accessToken ||
@@ -53,9 +53,13 @@ export const EmbeddedIFrameWrapper = (
       }
 
       const targetOrigin = new URL(spacesUrl).origin
-      const messageId = `init_${Date.now()}_${Math.random()
-        .toString(36)
-        .substring(2, 11)}`
+
+      // Generate messageId only on first attempt
+      if (!messageId) {
+        messageId = `init_${Date.now()}_${Math.random()
+          .toString(36)
+          .substring(2, 11)}`
+      }
 
       // Don't send if already acknowledged
       if (acknowledgedMessagesRef.current.has(messageId)) {
@@ -90,11 +94,11 @@ export const EmbeddedIFrameWrapper = (
         const retryDelay = Math.min(500 * Math.pow(2, retryCount), 8000) // Cap at 8 seconds
         const timeoutId = setTimeout(() => {
           retryTimeoutsRef.current.delete(timeoutId as unknown as number)
-          if (!acknowledgedMessagesRef.current.has(messageId)) {
+          if (!acknowledgedMessagesRef.current.has(messageId!)) {
             console.debug(
               `No acknowledgment received for messageId ${messageId}, retrying...`
             )
-            sendInitializeMessage(retryCount + 1)
+            sendInitializeMessage(retryCount + 1, messageId)
           }
         }, retryDelay) as unknown as number
 


### PR DESCRIPTION
Handles an issue where the `portal:initialize` postMessage to the spaces-ui iframe is sent before the app has loaded in the iframe. In particular this can happen if the `FlatfileProvider` is mounted at the same time as the portal is opened.

This resolves this issue by retrying the `portal:initialize` message until it is acked by the spaces-ui iframe.

See: https://github.com/FlatFilers/Platform/pull/10468