### PR TITLE
Bun Powered CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36169,7 +36169,7 @@
     },
     "packages/cli": {
       "name": "flatfile",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@flatfile/cross-env-config": "^0.0.6",
         "@flatfile/listener": "^1.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,18 +1,19 @@
 {
   "name": "flatfile",
-  "version": "3.11.1",
+  "version": "4.0.0",
   "description": "",
   "main": "./dist/index.js",
   "bin": {
     "flatfile": "./dist/index.js"
   },
+  "type": "module",
   "files": [
     "dist",
     "templates"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
+    "build": "bun build src/index.ts --target node --outdir dist",
+    "dev": "bun run src/index.ts --target node --watch",
     "lint": "TIMING=1 eslint \"src/**/*.{ts,tsx,js,jsx}\" --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "jest --runInBand --forceExit --passWithNoTests"


### PR DESCRIPTION
Honestly I have no idea if this is a viable change or not, but it works on my machine.

This changes 3 things:
- The CLI is now built via bun instead of node
- The CLI can now be run via bun instead of npx
- The deploy command now detects whether or not it's running in node or bun and compiles the agent code using Bun.build if it's running in bun. If it's running in node it uses the old ncc compiler. 

This makes agent code compilation basically instant and reduces total time to deploy by ~66%. 

<img width="1334" height="474" alt="image" src="https://github.com/user-attachments/assets/9b345560-7a6d-4eae-8e86-3314a05a6c5b" />


