### PR TITLE
fix: skip namespace prompt in deploy command when --ci flag is used

### DIFF
--- a/.changeset/fix-ci-flag-namespace-prompt.md
+++ b/.changeset/fix-ci-flag-namespace-prompt.md
@@ -1,0 +1,7 @@
+---
+"flatfile": patch
+---
+
+Fix CLI deploy command namespace prompt in CI mode
+
+The deploy command's namespace prompt was not respecting the --ci flag, causing CI pipelines to hang when no namespace was provided via options or environment variables. Now the prompt is skipped in CI mode.

--- a/packages/cli/src/x/actions/deploy.action.ts
+++ b/packages/cli/src/x/actions/deploy.action.ts
@@ -275,7 +275,7 @@ export async function deployAction(
 
     const namespacePrefixes = ['space:', 'workbook:', 'sheet:']
     let namespace = options?.namespace
-    if (!selectedAgent && !namespace && !process.env.FLATFILE_AGENT_NAMESPACE) {
+    if (!selectedAgent && !namespace && !process.env.FLATFILE_AGENT_NAMESPACE && !options?.ci) {
       const input = await prompts(
         {
           type: 'text',


### PR DESCRIPTION
Fixes the CLI deploy command's incomplete handling of the --ci flag.

## Problem
The namespace prompt in the deploy command was not respecting the --ci flag, causing CI pipelines to hang when:
- No namespace was provided via --namespace option
- No FLATFILE_AGENT_NAMESPACE environment variable was set
- No existing agent was selected

## Solution
Added a check for the --ci flag in the namespace prompt condition. Now the prompt is skipped in CI mode, preventing pipeline blocking.

## Changes
- Updated deploy.action.ts to check options?.ci before showing namespace prompt
- Added changeset documenting the fix

## Testing
The fix ensures that in CI mode, the deploy command will proceed without interactive prompts for namespace input.