### PR TITLE
added env flag to cli

### DIFF
--- a/.changeset/rich-suits-turn.md
+++ b/.changeset/rich-suits-turn.md
@@ -1,0 +1,5 @@
+---
+'flatfile': minor
+---
+
+add --env flag to deploy command and fetch environment directly by ID


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Fixes deployment failures for accounts with more than 100 environments by fetching the environment directly by ID when provided, instead of listing all environments and filtering. Also adds the -e, --env flag to the deploy command for consistency with the develop command.

## Tell code reviewer how and what to test:

