### PR TITLE
CLI: update uuid dependency

### DIFF
--- a/.changeset/four-owls-join.md
+++ b/.changeset/four-owls-join.md
@@ -1,0 +1,5 @@
+---
+"flatfile": patch
+---
+
+Update the CLI's uuid dependency so new installs resolve outside the reported uuid advisory range.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10342,12 +10342,6 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
-    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -30850,18 +30844,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -36772,7 +36754,7 @@
         "table": "^6.8.1",
         "tsup": "^8.5.1",
         "util": "^0.12.5",
-        "uuid": "^9.0.0",
+        "uuid": "^11.1.1",
         "wildcard-match": "^5.1.2",
         "zod": "^3.19.1"
       },
@@ -36794,7 +36776,6 @@
         "@types/rc": "^1.2.1",
         "@types/simple-mock": "^0.8.2",
         "@types/tar": "^6.1.13",
-        "@types/uuid": "^9.0.0",
         "boxen": "^7.0.0",
         "chalk": "^4.1.2",
         "inquirer": "^9.1.3",
@@ -37889,6 +37870,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.4",
         "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "packages/cli/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/cli/node_modules/webidl-conversions": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "table": "^6.8.1",
     "tsup": "^8.5.1",
     "util": "^0.12.5",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.1",
     "wildcard-match": "^5.1.2",
     "zod": "^3.19.1"
   },
@@ -61,7 +61,6 @@
     "@types/rc": "^1.2.1",
     "@types/simple-mock": "^0.8.2",
     "@types/tar": "^6.1.13",
-    "@types/uuid": "^9.0.0",
     "boxen": "^7.0.0",
     "chalk": "^4.1.2",
     "inquirer": "^9.1.3",


### PR DESCRIPTION
## Issue

The CLI still depends on `uuid` `^9.0.0`, which resolves inside the reported advisory range. Downstream listener repos can inherit that finding through `flatfile -> uuid`.

## What changed

- Updated the CLI `uuid` dependency to `^11.1.1`.
- Removed `@types/uuid` because `uuid` now ships its own types.
- Added a patch changeset for `flatfile`.

## Validation

- CLI lint and build pass.
- The CLI workspace audit no longer reports a `uuid` finding.